### PR TITLE
docs: add CONTRIBUTING, AGENTS, rewrite README, add DocC CI

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -1,0 +1,45 @@
+name: docc
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build DocC
+        run: |
+          chmod +x build-docc.sh
+          ./build-docc.sh
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .docs
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository.
+
+## What this project is
+
+A SwiftUI renderer for the [A2UI protocol](https://github.com/google/A2UI). It takes `ServerToClientMessage` JSON streams from AI agents and renders them as fully native Apple platform UIs. The public surface is one view: `A2UIRendererView`.
+
+## Commands
+
+```bash
+swift test                          # run all tests (must pass with 0 failures)
+swift test --filter <TestName>      # run a single test class
+open A2UIDemoApp/A2UIDemoApp.xcodeproj  # open demo app in Xcode
+```
+
+No build script. No Makefile. No dependencies beyond the Swift toolchain and Apple SDKs.
+
+## Architecture
+
+```
+A2UIRendererView          ← only public API (3 initializers)
+    └── SurfaceManager    ← @Observable, owns all surface state
+        └── SurfaceViewModel (per surface)
+            └── ComponentNode tree (pre-resolved, rebuilt on each update)
+                └── A2UIComponentView (recursive renderer, read-only)
+                    └── A2UI{Component}.swift (one file per component type)
+```
+
+**Key invariant:** `A2UIComponentView` and all component views are read-only. They never mutate state directly. All tree mutations go through `SurfaceManager`.
+
+**UI state** (e.g., selected tab index, modal presentation) lives on `ComponentNode.uiState` — an `@Observable` object that is migrated by ID across tree rebuilds, so it survives `LazyVStack` recycling.
+
+**Styling** flows through the SwiftUI `Environment` as `A2UIStyle`. Never pass style as an explicit parameter to component views.
+
+## File map
+
+| Path | Purpose |
+|------|---------|
+| `Sources/A2UI/A2UIRenderer.swift` | Public API — `A2UIRendererView` |
+| `Sources/A2UI/Models/Messages.swift` | `ServerToClientMessage`, `ClientToServerMessage` |
+| `Sources/A2UI/Models/Components.swift` | `A2UIComponent` tagged union |
+| `Sources/A2UI/Models/ComponentTypes.swift` | Per-component `Codable` structs |
+| `Sources/A2UI/Models/Primitives.swift` | Shared value types (`Color`, `Action`, etc.) |
+| `Sources/A2UI/Processing/SurfaceManager.swift` | `@Observable` state, message processing |
+| `Sources/A2UI/Processing/JSONLStreamParser.swift` | Async JSONL → message stream |
+| `Sources/A2UI/Views/A2UIComponentView.swift` | Top-level component switch |
+| `Sources/A2UI/Views/Components/` | One `.swift` per component |
+| `Sources/A2UI/Views/Components/COMPONENT_DECISIONS.md` | Design rationale per component |
+| `Sources/A2UI/Styling/A2UIStyle.swift` | Theme system + Environment integration |
+| `Sources/A2UI/Networking/A2AClient.swift` | JSON-RPC over HTTP |
+| `Tests/A2UITests/` | 87 tests across 5 files |
+
+## Rules
+
+### Do
+- Use `@Observable` for any new state-holding types
+- Use `@Environment(\.a2uiStyle)` to read styling — never hardcode colors, padding, or corner radii
+- Use `#if os(watchOS)` / `#if os(tvOS)` for platform-specific fallbacks
+- Prefer system SwiftUI controls over custom drawing
+- Keep `A2UIComponentView` and child views read-only
+- Add an entry to `COMPONENT_DECISIONS.md` when making a non-obvious implementation choice
+- Write tests for every new decode path: happy path, missing optional fields, Codable round-trip
+
+### Don't
+- Use `ObservableObject` / `@StateObject` / `@Published` — this codebase uses `@Observable`
+- Use `AnyView` — use generics or `@ViewBuilder`
+- Add third-party dependencies
+- Hardcode any numeric values (spacing, radii, font sizes) — pull from `A2UIStyle`
+- Mutate component tree state from inside a view
+- Skip `swift test` before completing a task
+
+## Adding a component
+
+1. **Model** — add a `Codable` struct in `ComponentTypes.swift`. All properties optional with sensible defaults.
+2. **Register** — add a case to `A2UIComponent` in `Components.swift` and handle it in `init(from:)`.
+3. **View** — create `Sources/A2UI/Views/Components/A2UI{Name}.swift`. Follow the conventions above.
+4. **Wire** — add a `case` in `A2UIComponentView.renderComponent(_:)`.
+5. **Test** — add decode tests in `Tests/A2UITests/MessageDecodingTests.swift` or a new file.
+6. **Document** — add an entry to `COMPONENT_DECISIONS.md`.
+
+## Testing conventions
+
+Test files live in `Tests/A2UITests/`. JSON fixtures go in `Tests/A2UITests/TestData/`.
+
+Each test file has a clear scope:
+- `MessageDecodingTests.swift` — JSON → model decode
+- `DataBindingTests.swift` — data binding / path resolution
+- `PrimitivesTests.swift` — primitive value types
+- `MultipleChoiceLogicTests.swift` — selection logic
+- `TextFieldValidationTests.swift` — regex validation
+
+When adding tests, match the existing file structure. Prefer small, focused test functions over large ones. Use `XCTAssertEqual` rather than `XCTAssert` so failures show the actual vs expected values.
+
+## Platform support matrix
+
+| Feature | iOS | macOS | visionOS | watchOS | tvOS |
+|---------|-----|-------|----------|---------|------|
+| `@Observable` | ✅ 17+ | ✅ 14+ | ✅ 1+ | ✅ 10+ | ✅ 17+ |
+| `AVPlayerViewController` | ✅ | ❌ (use `AVPlayerView`) | ✅ | ❌ | ✅ |
+| `DatePicker` | ✅ | ✅ | ✅ | ✅ | ❌ (fallback: read-only text) |
+| `Slider` | ✅ | ✅ | ✅ | ✅ | ❌ (fallback: +/− buttons) |
+| `TextEditor` | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `.segmented` Picker | ✅ | ✅ | ✅ | ❌ (fallback: `.wheel`) | ❌ |
+
+When a control is unavailable on a platform, provide a functional fallback — never silently render nothing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to A2UI SwiftUI Renderer
+
+Thank you for your interest in contributing. This guide covers everything you need to get started.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Running Tests](#running-tests)
+- [Project Structure](#project-structure)
+- [Adding a Component](#adding-a-component)
+- [Good First Issues](#good-first-issues)
+- [Submitting a Pull Request](#submitting-a-pull-request)
+
+---
+
+## Getting Started
+
+```bash
+git clone https://github.com/BBC6BAE9/a2ui-swiftui.git
+cd a2ui-swiftui
+open A2UIDemoApp/A2UIDemoApp.xcodeproj  # optional: run the demo app
+```
+
+No dependencies beyond the Swift toolchain. The package resolves entirely from the standard library and Apple SDKs.
+
+---
+
+## Running Tests
+
+```bash
+swift test
+```
+
+All 87 tests should pass. The test suite covers message decoding, component parsing, data binding, JSONL streaming, incremental surface updates, and Codable round-trips.
+
+To run a specific test file:
+
+```bash
+swift test --filter MessageDecodingTests
+```
+
+---
+
+## Project Structure
+
+```
+Sources/A2UI/
+├── Models/
+│   ├── Messages.swift          # ServerToClientMessage, ClientToServerMessage
+│   ├── Components.swift        # A2UIComponent (tagged union of all 18 types)
+│   ├── ComponentTypes.swift    # Per-component model structs
+│   └── Primitives.swift        # Shared value types (Color, Font, Action, etc.)
+├── Processing/
+│   ├── SurfaceManager.swift    # @Observable state — owns the component tree
+│   └── JSONLStreamParser.swift # Async JSONL → ServerToClientMessage stream
+├── Views/
+│   ├── A2UIComponentView.swift # Top-level switch — dispatches to component views
+│   └── Components/             # One file per component (A2UIText.swift, etc.)
+│       └── COMPONENT_DECISIONS.md  # Design rationale for every component
+├── Styling/
+│   └── A2UIStyle.swift         # Theme system — passed via SwiftUI Environment
+├── Networking/
+│   └── A2AClient.swift         # JSON-RPC over HTTP for A2A agent connections
+└── A2UIRenderer.swift          # Public API — A2UIRendererView (3 initializers)
+```
+
+---
+
+## Adding a Component
+
+The A2UI spec defines all standard components. If you're implementing a missing non-standard extension or improving an existing component, follow these steps:
+
+### 1. Add the model (if new)
+
+In `Sources/A2UI/Models/ComponentTypes.swift`, add a `Codable` struct for the new component. Follow the existing pattern — all properties should be optional with sensible defaults where the spec allows.
+
+### 2. Register the type
+
+In `Sources/A2UI/Models/Components.swift`, add a case to the `A2UIComponent` enum and handle it in the `init(from:)` decoder.
+
+### 3. Create the view
+
+Create `Sources/A2UI/Views/Components/A2UIYourComponent.swift`. Key conventions:
+
+- **No hardcoded colors, padding, or corner radii** — pull from `A2UIStyle` via `@Environment`
+- **Use idiomatic SwiftUI** — prefer system controls over custom drawing
+- **Platform conditionals** via `#if os(watchOS)` / `#if os(tvOS)` for unavailable APIs
+- **Document non-obvious decisions** — add an entry to `COMPONENT_DECISIONS.md`
+
+### 4. Wire up the renderer
+
+In `Sources/A2UI/Views/A2UIComponentView.swift`, add a `case` for the new component in the main `switch`.
+
+### 5. Write tests
+
+Add test cases in `Tests/A2UITests/MessageDecodingTests.swift` (or a new file if warranted). At minimum, test:
+- Successful decode from JSON
+- Default values when optional fields are absent
+- Codable round-trip
+
+---
+
+## Good First Issues
+
+If you're new to the codebase, these are well-scoped starting points:
+
+| Area | Task |
+|------|------|
+| **Tests** | Add edge-case JSON inputs to `TestData/` and corresponding decode tests |
+| **Icon mapping** | Expand the Material → SF Symbol mapping table in `A2UIIcon.swift` |
+| **Styling** | Expose additional `A2UIStyle` properties for existing components |
+| **Accessibility** | Audit components for missing `.accessibilityLabel` / `.accessibilityHint` annotations |
+| **Documentation** | Add or improve inline doc comments (`///`) on public API types |
+| **tvOS** | Improve fallback UIs for components with limited tvOS support |
+
+---
+
+## Submitting a Pull Request
+
+1. **Fork** the repo and create a branch from `main`
+2. **Make your changes** — keep commits focused and the diff readable
+3. **Run the tests** — `swift test` must pass with 0 failures
+4. **Open a PR** — describe what you changed and why; link any relevant A2UI spec sections
+
+For significant changes (new components, API changes, architectural decisions), open an issue first to align on approach before writing code.
+
+---
+
+## Code Style
+
+- Follow Swift API Design Guidelines
+- Use `@Observable` for any new state-holding types (not `ObservableObject`)
+- Avoid `AnyView` — prefer generics or `@ViewBuilder`
+- No third-party dependencies
+
+---
+
+Questions? Open an issue or start a Discussion.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,60 @@
 # A2UI SwiftUI Renderer
 
-A native SwiftUI renderer for the [A2UI](https://github.com/google/A2UI) protocol.
-Renders agent-generated JSON into native iOS and macOS interfaces using SwiftUI.
+**Render AI agent interfaces natively on Apple platforms — no WebView, no compromise.**
 
-This is a community-maintained renderer for the A2UI specification.
+A SwiftUI renderer for the [A2UI](https://github.com/google/A2UI) protocol. Drop in `A2UIRendererView` and your agent's JSON surfaces become fully native iOS, macOS, visionOS, watchOS, and tvOS interfaces — complete with live streaming, two-way data binding, and the full SwiftUI component lifecycle.
+
+![Swift](https://img.shields.io/badge/Swift-5.9+-orange?logo=swift)
+![Platforms](https://img.shields.io/badge/Platforms-iOS%2017%20%7C%20macOS%2014%20%7C%20visionOS%201%20%7C%20watchOS%2010%20%7C%20tvOS%2017-blue)
+![License](https://img.shields.io/badge/License-MIT-green)
+![Tests](https://img.shields.io/badge/Tests-87%20passing-brightgreen)
+
 | iOS | iPadOS | macOS | visionOS | watchOS | tvOS |
 |:---:|:------:|:-----:|:--------:|:-------:|:----:|
 | <img src="https://github.com/user-attachments/assets/b765127a-b97f-4767-a2ef-98f2d8f3f96e" height="280"/> | <img src="https://github.com/user-attachments/assets/902e5e55-f556-4112-b8ec-09ec9f991231" height="280"/> | <img src="https://github.com/user-attachments/assets/1eacae69-f8ba-4285-bb3d-dad1bd8eefb0" height="280"/> | <img src="https://github.com/user-attachments/assets/99e8c253-130c-4b09-a661-9b5aaeff2b5f" height="280"/> | <img src="https://github.com/user-attachments/assets/6bbd46f5-8ff0-4360-9d39-9175444843bf" height="280"/> | <img src="https://github.com/user-attachments/assets/f3e16070-e0e6-4862-a393-c12543816fbe" height="280"/> |
 
+## Why SwiftUI?
 
+Most agent UI renderers use WebView or custom draw loops. This renderer maps every A2UI component to its idiomatic SwiftUI counterpart — `HStack`, `LazyVStack`, `DatePicker`, `.sheet`, and so on. You get:
+
+- **Native performance** — no WebView overhead, no bridge layer
+- **Platform adaptivity** — the same JSON renders appropriately on iPhone, Mac, Apple Watch, and Apple Vision Pro
+- **SwiftUI ecosystem** — themes, accessibility, Dark Mode, Dynamic Type, and environment values just work
+- **Property-level reactivity** — powered by `@Observable` (Observation framework), matching the Signal-based approach of the official Lit and Angular renderers
 
 ## Requirements
 
-- iOS 17.0+ / macOS 14.0+
+- iOS 17.0+ / macOS 14.0+ / visionOS 1.0+ / watchOS 10.0+ / tvOS 17.0+
 - Swift 5.9+
 - Xcode 15+
 
 ## Installation
 
-Since the `Package.swift` lives in the `renderers/swiftui/` subdirectory (not the
-repository root), use a local path reference:
+Add this package to your project via Swift Package Manager:
 
 **In `Package.swift`:**
 
 ```swift
 dependencies: [
-    .package(path: "../path/to/A2UI/renderers/swiftui"),
+    .package(url: "https://github.com/BBC6BAE9/a2ui-swiftui", branch: "main"),
+],
+targets: [
+    .target(name: "YourApp", dependencies: ["A2UI"]),
 ]
 ```
 
-**In Xcode:** File → Add Package Dependencies → Add Local… → select the
-`renderers/swiftui` directory.
+**In Xcode:** File → Add Package Dependencies → paste the repository URL.
 
 ## Quick Start
+
+### Static JSON
 
 ```swift
 import A2UI
 
-// 1. Load A2UI messages (from a JSON file, network response, etc.)
-let data = try Data(contentsOf: jsonFileURL)
+// Decode A2UI messages from a JSON payload
 let messages = try JSONDecoder().decode([ServerToClientMessage].self, from: data)
 
-// 2. Render the surface
 A2UIRendererView(messages: messages)
 ```
 
@@ -50,13 +63,13 @@ A2UIRendererView(messages: messages)
 ```swift
 import A2UI
 
-// Stream messages from an A2A agent
-A2UIRendererView(stream: messageStream, onAction: { action in
+// Connect directly to a streaming A2A agent
+A2UIRendererView(stream: messageStream) { action in
     print("User triggered: \(action.name)")
-})
+}
 ```
 
-### JSONL Stream Parsing
+### JSONL over URLSession
 
 ```swift
 import A2UI
@@ -64,13 +77,12 @@ import A2UI
 let parser = JSONLStreamParser()
 let manager = SurfaceManager()
 
-// Parse from async byte stream (e.g. URLSession)
 let (bytes, _) = try await URLSession.shared.bytes(for: request)
 for try await message in parser.messages(from: bytes) {
     try manager.processMessage(message)
 }
 
-// Render in SwiftUI — View only observes, no stream logic
+// View only observes — no stream logic in the view layer
 A2UIRendererView(manager: manager)
 ```
 
@@ -80,11 +92,12 @@ All 18 standard A2UI components are implemented:
 
 | Category | Components |
 |----------|-----------|
-| Display | Text, Image, Icon, Video, AudioPlayer, Divider |
-| Layout | Row, Column, List, Card, Tabs, Modal |
-| Input | Button, TextField, CheckBox, DateTimeInput, Slider, MultipleChoice |
+| Display  | Text, Image, Icon, Video, AudioPlayer, Divider |
+| Layout   | Row, Column, List, Card, Tabs, Modal |
+| Input    | Button, TextField, CheckBox, DateTimeInput, Slider, MultipleChoice |
 
-### Component Mapping
+<details>
+<summary>Full component mapping</summary>
 
 | A2UI Component | SwiftUI Implementation |
 |---------------|----------------------|
@@ -107,87 +120,64 @@ All 18 standard A2UI components are implemented:
 | MultipleChoice | Checkbox list or chips (FlowLayout) with filtering |
 | Divider | `SwiftUI.Divider` |
 
+</details>
+
 ## Architecture
 
 ```
 Sources/A2UI/
-├── Models/         Codable data models (Messages, Components, Primitives)
-├── Processing/     SurfaceViewModel (state) + JSONLStreamParser (streaming)
-├── Views/          A2UIComponentView (recursive renderer)
-├── Styling/        A2UIStyle + SwiftUI Environment integration
-├── Networking/     A2AClient (JSON-RPC over HTTP)
+├── Models/           Codable data models (Messages, Components, Primitives)
+├── Processing/       SurfaceManager (state) + JSONLStreamParser (streaming)
+├── Views/            A2UIComponentView (recursive renderer)
+├── Styling/          A2UIStyle + SwiftUI Environment integration
+├── Networking/       A2AClient (JSON-RPC over HTTP)
 └── A2UIRenderer.swift   Public API entry point
 ```
 
-The renderer uses `@Observable` (Observation framework) for property-level
-reactivity, matching the Signal-based approach used by the official Lit and
-Angular renderers.
-
-## Running Tests
-
-```bash
-cd renderers/swiftui
-swift test
-```
-
-84 tests across 5 test files cover message decoding, component parsing, data
-binding, path resolution, template rendering, catalog functions, validation,
-JSONL streaming, incremental updates, and Codable round-trips.
+The public API is a single view — `A2UIRendererView` — with three initializers covering static, streamed, and externally-managed surfaces. All state lives in `SurfaceManager`, keeping the view layer pure.
 
 ## Demo App
 
-The demo app is located at `samples/client/swiftui/A2UIDemoApp/` in the
-repository root. It demonstrates both offline sample rendering and live A2A
-agent integration.
+Open `A2UIDemoApp/A2UIDemoApp.xcodeproj` in Xcode and run on a simulator or device.
 
-Open `samples/client/swiftui/A2UIDemoApp/A2UIDemoApp.xcodeproj` in Xcode and run on a
-simulator or device.
+The app includes **10 demo pages** covering static JSON rendering and live A2A agent connections. Each page has an **info inspector** explaining what it demonstrates; action-triggering pages display a **Resolved Action log** showing the full context payload.
 
 |                             info                             |                          action log                          |                            genui                             |
 | :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
 | <img src="https://github.com/user-attachments/assets/1cefe139-3266-4b57-8f2e-d4d2046b3ae6" height="200"/> | <img src="https://github.com/user-attachments/assets/f65a68a3-78a7-4542-8bf4-868ce0e91ec4" height="200"/> | <img src="https://github.com/user-attachments/assets/3b38f7c5-3b7e-4910-9222-bfa2c7cf236b" height="200"/> |
 
-The demo app (`samples/client/swiftui/`) includes **10 pages** covering both static JSON demos and live agent connections. Each demo page includes an **info inspector** explaining what it demonstrates, and action-triggering pages display a **Resolved Action** log showing the resolved context payload.
+> Live agent demo: [BBC6BAE9/genui](https://github.com/BBC6BAE9/genui)
 
-genui demo: https://github.com/BBC6BAE9/genui
+## Testing
+
+```bash
+swift test
+```
+
+87 tests across 5 test files cover message decoding, component parsing, data binding, path resolution, template rendering, catalog functions, validation, JSONL streaming, incremental updates, and Codable round-trips.
 
 ## Known Limitations
 
-- Requires iOS 17+ / macOS 14+ (uses `@Observable` from the Observation framework).
-- Custom (non-standard) component types are decoded but not rendered.
-- Video playback uses `UIViewControllerRepresentable` on iOS; macOS uses a
-  `VideoPlayer` fallback.
-- No built-in Content Security Policy enforcement for image/video URLs —
-  applications should validate URLs from untrusted agents.
+- Requires iOS 17+ / macOS 14+ (uses `@Observable` from the Observation framework)
+- Custom (non-standard) component types are decoded but not rendered
+- Video playback uses `UIViewControllerRepresentable` on iOS; macOS uses a `VideoPlayer` fallback
+- No built-in Content Security Policy enforcement for image/video URLs — applications should validate URLs from untrusted agents
 
 ## Security
 
-**Important:** The sample code provided is for demonstration purposes and
-illustrates the mechanics of A2UI and the Agent-to-Agent (A2A) protocol. When
-building production applications, it is critical to treat any agent operating
-outside of your direct control as a potentially untrusted entity.
+When building production applications, treat any agent operating outside your direct control as an untrusted entity. All data received from an external agent — AgentCard, messages, artifacts, task statuses — should be handled as untrusted input.
 
-All operational data received from an external agent — including its AgentCard,
-messages, artifacts, and task statuses — should be handled as untrusted input.
-For example, a malicious agent could provide crafted data in its fields (e.g.,
-name, skills.description) that, if used without sanitization to construct
-prompts for a Large Language Model (LLM), could expose your application to
-prompt injection attacks.
+Concretely:
+- **Prompt injection:** agent-supplied strings (name, description, etc.) must be sanitized before being used to construct LLM prompts
+- **Phishing / UI spoofing:** validate the identity of agents before rendering their surfaces
+- **XSS:** if your app embeds web content, apply a strict Content Security Policy
+- **DoS:** enforce limits on layout complexity for surfaces from untrusted agents
 
-Similarly, any UI definition or data stream received must be treated as
-untrusted. Malicious agents could attempt to spoof legitimate interfaces to
-deceive users (phishing), inject malicious scripts via property values (XSS),
-or generate excessive layout complexity to degrade client performance (DoS). If
-your application supports optional embedded content (such as iframes or web
-views), additional care must be taken to prevent exposure to malicious external
-sites.
+Developers are responsible for input sanitization, sandboxing rendered content, and secure credential handling. The sample code in this repository is for demonstration purposes only.
 
-**Developer Responsibility:** Failure to properly validate data and strictly
-sandbox rendered content can introduce severe vulnerabilities. Developers are
-responsible for implementing appropriate security measures — such as input
-sanitization, Content Security Policies (CSP), strict isolation for optional
-embedded content, and secure credential handling — to protect their systems and
-users.
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add components, run tests, and submit PRs.
 
 ## License
 

--- a/build-docc.sh
+++ b/build-docc.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+xcrun xcodebuild docbuild \
+    -scheme A2UI \
+    -destination 'generic/platform=iOS Simulator' \
+    -derivedDataPath "$PWD/.derivedData"
+
+xcrun docc process-archive transform-for-static-hosting \
+    "$PWD/.derivedData/Build/Products/Debug-iphonesimulator/A2UI.doccarchive" \
+    --output-path ".docs" \
+    --hosting-base-path "a2ui-swiftui"
+
+echo '<script>window.location.href += "/documentation/a2ui"</script>' > .docs/index.html


### PR DESCRIPTION
## Summary

- Rewrite README: fix broken install paths (monorepo → standalone SPM), add badges, add "Why SwiftUI?" section, correct test count (84→87), fix demo app path
- Add `CONTRIBUTING.md` with step-by-step component guide, project structure, and good first issues table
- Add `AGENTS.md` with precise conventions for AI coding agents (architecture, rules, platform matrix)
- Add DocC GitHub Actions workflow + `build-docc.sh` for automated documentation deployment to GitHub Pages

## Docs site

Will be live at https://bbc6bae9.github.io/a2ui-swiftui/ after merge and CI run.