### PR TITLE
fix: correct git-cliff binary download URL format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,11 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          curl -sSL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
-            | tar -xz --strip-components=1 git-cliff-*/git-cliff
+          VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${VERSION}/git-cliff-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz --strip-components=1
           sudo mv git-cliff /usr/local/bin/
 
       - name: Generate changelog


### PR DESCRIPTION
Dynamic version lookup + correct versioned tarball path. Fixes the gzip format error from the previous attempt.