### PR TITLE
fix(sample_0.8): correct local SPM package path and remove stale A2UI dependencies

### DIFF
--- a/samples/sample_0.8/A2UIDemoApp.xcodeproj/project.pbxproj
+++ b/samples/sample_0.8/A2UIDemoApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F1143E702F51B7000037701E /* A2UI in Frameworks */ = {isa = PBXBuildFile; productRef = F1143E6F2F51B7000037701E /* A2UI */; };
+		F1143E702F51B7000037701E /* v_08 in Frameworks */ = {isa = PBXBuildFile; productRef = F1143E6F2F51B7000037701E /* v_08 */; };
 		F11A75472F78399900527023 /* v_08 in Frameworks */ = {isa = PBXBuildFile; productRef = F11A75462F78399900527023 /* v_08 */; };
 /* End PBXBuildFile section */
 
@@ -34,7 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F1143E702F51B7000037701E /* A2UI in Frameworks */,
+				F1143E702F51B7000037701E /* v_08 in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,7 +87,7 @@
 			);
 			name = "A2UIDemoWatchApp Watch App";
 			packageProductDependencies = (
-				F1143E6F2F51B7000037701E /* A2UI */,
+				F1143E6F2F51B7000037701E /* v_08 */,
 			);
 			productName = "A2UIDemoWatchApp Watch App";
 			productReference = F1143E392F51B6CD0037701E /* A2UIDemoWatchApp Watch App.app */;
@@ -110,9 +110,6 @@
 			);
 			name = A2UIDemoApp;
 			packageProductDependencies = (
-				F1FAD1B12F4DA70000BE5C9D /* A2UI */,
-				F1638D0A2F628F40004D5BC4 /* A2UI */,
-				F1CE8AFF2F72BB080060C78C /* A2UI */,
 				F11A75462F78399900527023 /* v_08 */,
 			);
 			productName = A2UIDemoApp;
@@ -147,7 +144,7 @@
 			mainGroup = F1FAD17E2F4DA60400BE5C9D;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../../../a2ui-swiftui" */,
+				F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F1FAD1882F4DA60400BE5C9D /* Products */;
@@ -511,32 +508,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../../../a2ui-swiftui" */ = {
+		F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../a2ui-swiftui";
+			relativePath = "../..";
 		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F1143E6F2F51B7000037701E /* A2UI */ = {
+		F1143E6F2F51B7000037701E /* v_08 */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = A2UI;
+			productName = v_08;
 		};
 		F11A75462F78399900527023 /* v_08 */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = v_08;
-		};
-		F1638D0A2F628F40004D5BC4 /* A2UI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = A2UI;
-		};
-		F1CE8AFF2F72BB080060C78C /* A2UI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = A2UI;
-		};
-		F1FAD1B12F4DA70000BE5C9D /* A2UI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = A2UI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
## Summary
- Fix `XCLocalSwiftPackageReference` path from `../../../a2ui-swiftui` to `../..` so it correctly resolves to the repo root where `Package.swift` lives
- Remove 3 stale `A2UI` product dependencies from A2UIDemoApp target (product no longer exists in Package.swift)
- Replace WatchApp's `A2UI` dependency with `v_08` to match source imports

## Test plan
- [ ] Open `samples/sample_0.8/A2UIDemoApp.xcodeproj` in Xcode
- [ ] Verify the local SPM package resolves successfully
- [ ] Build A2UIDemoApp target (iOS/macOS)
- [ ] Build A2UIDemoWatchApp target (watchOS)

Made with [Cursor](https://cursor.com)