### PR TITLE
fix: enforce strict v0.9 schema validation

### DIFF
--- a/Sources/A2UISwiftCore/Schema/ClientToServer.swift
+++ b/Sources/A2UISwiftCore/Schema/ClientToServer.swift
@@ -94,10 +94,44 @@ public enum A2uiClientMessage: Codable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let action = try container.decodeIfPresent(A2uiClientAction.self, forKey: .action) {
+        let raw = try AnyCodable(from: decoder)
+        guard case .dictionary(let dict) = raw else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "A2uiClientMessage must be a JSON object."
+            ))
+        }
+
+        let allowedKeys: Set<String> = ["version", "action", "error"]
+        let extraKeys = Set(dict.keys).subtracting(allowedKeys)
+        guard extraKeys.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "A2uiClientMessage contains unsupported properties: \(extraKeys.sorted().joined(separator: ", "))."
+            ))
+        }
+
+        guard dict["version"]?.stringValue == "v0.9" else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "A2uiClientMessage version must be 'v0.9'."
+            ))
+        }
+
+        let data = try JSONEncoder().encode(raw)
+        let container = try JSONDecoder().decode(DecodedMessage.self, from: data)
+        let hasAction = container.action != nil
+        let hasError = container.error != nil
+        guard hasAction != hasError else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "A2uiClientMessage must contain exactly one of 'action' or 'error'."
+            ))
+        }
+
+        if let action = container.action {
             self = .action(action)
-        } else if let error = try container.decodeIfPresent(A2uiClientError.self, forKey: .error) {
+        } else if let error = container.error {
             self = .error(error)
         } else {
             throw DecodingError.dataCorrupted(.init(
@@ -114,6 +148,12 @@ public enum A2uiClientMessage: Codable {
         case .action(let a): try container.encode(a, forKey: .action)
         case .error(let e): try container.encode(e, forKey: .error)
         }
+    }
+
+    private struct DecodedMessage: Codable {
+        let version: String
+        let action: A2uiClientAction?
+        let error: A2uiClientError?
     }
 }
 

--- a/Sources/A2UISwiftCore/Schema/CommonTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/CommonTypes.swift
@@ -48,29 +48,66 @@ public struct FunctionCall: Codable, Sendable {
 /// 让泛型 Dynamic<T> 知道如何从 AnyCodable 提取字面量，以及提供默认值。
 public protocol LiteralDecodable: Codable {
     static func fromAnyCodable(_ value: AnyCodable) -> Self?
-    static var defaultLiteral: Self { get }
 }
 
 extension String: LiteralDecodable {
     public static func fromAnyCodable(_ value: AnyCodable) -> String? { value.stringValue }
-    public static var defaultLiteral: String { "" }
 }
 
 extension Double: LiteralDecodable {
     public static func fromAnyCodable(_ value: AnyCodable) -> Double? { value.numberValue }
-    public static var defaultLiteral: Double { 0 }
 }
 
 extension Bool: LiteralDecodable {
     public static func fromAnyCodable(_ value: AnyCodable) -> Bool? { value.boolValue }
-    public static var defaultLiteral: Bool { false }
 }
 
 extension Array: LiteralDecodable where Element == String {
     public static func fromAnyCodable(_ value: AnyCodable) -> [String]? {
-        value.arrayValue?.compactMap(\.stringValue)
+        guard let values = value.arrayValue else { return nil }
+        var strings: [String] = []
+        strings.reserveCapacity(values.count)
+        for item in values {
+            guard let string = item.stringValue else { return nil }
+            strings.append(string)
+        }
+        return strings
     }
-    public static var defaultLiteral: [String] { [] }
+}
+
+private func schemaDecodingError(at codingPath: [any CodingKey], _ message: String) -> DecodingError {
+    DecodingError.dataCorrupted(.init(codingPath: codingPath, debugDescription: message))
+}
+
+private enum DynamicSchemaKind: String {
+    case string
+    case number
+    case boolean
+    case array
+
+    var functionReturnType: FunctionCallReturnType {
+        switch self {
+        case .string: return .string
+        case .number: return .number
+        case .boolean: return .boolean
+        case .array: return .array
+        }
+    }
+}
+
+private func dynamicSchemaKind<T>(for type: T.Type) -> DynamicSchemaKind? {
+    switch type {
+    case is String.Type:
+        return .string
+    case is Double.Type:
+        return .number
+    case is Bool.Type:
+        return .boolean
+    case is [String].Type:
+        return .array
+    default:
+        return nil
+    }
 }
 
 // MARK: - Dynamic<T>
@@ -84,16 +121,29 @@ public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let raw = try AnyCodable(from: decoder)
+        guard let schemaKind = dynamicSchemaKind(for: T.self) else {
+            throw schemaDecodingError(at: decoder.codingPath, "Unsupported Dynamic literal type: \(T.self).")
+        }
         if let literal = T.fromAnyCodable(raw) {
             self = .literal(literal)
-        } else if case .dictionary(let dict) = raw, let resolved = DynamicDictResolver.resolve(dict) {
+        } else if case .dictionary(let dict) = raw {
+            let resolved = try DynamicDictResolver.resolve(dict, codingPath: decoder.codingPath)
             switch resolved {
             case .dataBinding(let path): self = .dataBinding(path: path)
-            case .functionCall(let fc): self = .functionCall(fc)
+            case .functionCall(let fc):
+                if let returnType = fc.returnType, returnType != schemaKind.functionReturnType {
+                    throw schemaDecodingError(
+                        at: decoder.codingPath,
+                        "Dynamic<\(T.self)> function call must declare returnType '\(schemaKind.rawValue)'."
+                    )
+                }
+                self = .functionCall(fc)
             }
         } else {
-            assertionFailure("A2UI: Dynamic<\(T.self)> received unexpected value: \(raw)")
-            self = .literal(T.defaultLiteral)
+            throw schemaDecodingError(
+                at: decoder.codingPath,
+                "Dynamic<\(T.self)> must be a literal \(schemaKind.rawValue), data binding, or matching function call."
+            )
         }
     }
 
@@ -123,16 +173,49 @@ enum DynamicDictResolver {
         case functionCall(FunctionCall)
     }
 
-    static func resolve(_ dict: [String: AnyCodable]) -> Result? {
-        if let callName = dict["call"]?.stringValue {
-            let args = dict["args"]?.dictionaryValue ?? [:]
-            let returnType = dict["returnType"]?.stringValue.flatMap(FunctionCallReturnType.init(rawValue:))
-            return .functionCall(FunctionCall(call: callName, args: args, returnType: returnType))
-        }
-        if let path = dict["path"]?.stringValue {
+    static func resolve(_ dict: [String: AnyCodable], codingPath: [any CodingKey]) throws -> Result {
+        if dict.keys.contains("path") {
+            guard dict.count == 1, let path = dict["path"]?.stringValue else {
+                throw schemaDecodingError(at: codingPath, "DataBinding must be exactly {'path': string}.")
+            }
             return .dataBinding(path: path)
         }
-        return nil
+
+        if dict.keys.contains("call") || dict.keys.contains("args") || dict.keys.contains("returnType") {
+            let allowedKeys: Set<String> = ["call", "args", "returnType"]
+            let extraKeys = Set(dict.keys).subtracting(allowedKeys)
+            guard extraKeys.isEmpty else {
+                throw schemaDecodingError(
+                    at: codingPath,
+                    "FunctionCall contains unsupported properties: \(extraKeys.sorted().joined(separator: ", "))."
+                )
+            }
+            guard let callName = dict["call"]?.stringValue else {
+                throw schemaDecodingError(at: codingPath, "FunctionCall requires 'call' to be a string.")
+            }
+            let args: [String: AnyCodable]
+            if let rawArgs = dict["args"] {
+                guard let dictArgs = rawArgs.dictionaryValue else {
+                    throw schemaDecodingError(at: codingPath, "FunctionCall 'args' must be an object.")
+                }
+                args = dictArgs
+            } else {
+                args = [:]
+            }
+            let returnType: FunctionCallReturnType?
+            if let rawReturnType = dict["returnType"] {
+                guard let stringValue = rawReturnType.stringValue,
+                      let decodedReturnType = FunctionCallReturnType(rawValue: stringValue) else {
+                    throw schemaDecodingError(at: codingPath, "FunctionCall 'returnType' must be a valid spec enum value.")
+                }
+                returnType = decodedReturnType
+            } else {
+                returnType = nil
+            }
+            return .functionCall(FunctionCall(call: callName, args: args, returnType: returnType))
+        }
+
+        throw schemaDecodingError(at: codingPath, "Object does not match DataBinding or FunctionCall schema.")
     }
 }
 
@@ -151,28 +234,48 @@ public enum DynamicValue: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let raw = try AnyCodable(from: decoder)
-        self.init(from: raw)
+        self = try Self.decodeStrict(from: raw, codingPath: decoder.codingPath)
     }
 
     public init(from value: AnyCodable) {
+        self = Self.decodeLenient(from: value)
+    }
+
+    fileprivate static func decodeStrict(from value: AnyCodable, codingPath: [any CodingKey]) throws -> DynamicValue {
         switch value {
-        case .string(let s): self = .string(s)
-        case .number(let n): self = .number(n)
-        case .bool(let b): self = .bool(b)
-        case .array(let arr): self = .array(arr)
+        case .string(let s): return .string(s)
+        case .number(let n): return .number(n)
+        case .bool(let b): return .bool(b)
+        case .array(let arr): return .array(arr)
         case .dictionary(let dict):
-            if let resolved = DynamicDictResolver.resolve(dict) {
-                switch resolved {
-                case .dataBinding(let path): self = .dataBinding(path: path)
-                case .functionCall(let fc): self = .functionCall(fc)
-                }
-            } else {
-                assertionFailure("A2UI: DynamicValue received unresolvable object: \(dict)")
-                self = .string("")
+            let resolved = try DynamicDictResolver.resolve(dict, codingPath: codingPath)
+            switch resolved {
+            case .dataBinding(let path): return .dataBinding(path: path)
+            case .functionCall(let fc): return .functionCall(fc)
             }
         case .null:
-            assertionFailure("A2UI: DynamicValue received null, falling back to empty string.")
-            self = .string("")
+            throw schemaDecodingError(at: codingPath, "DynamicValue does not allow null.")
+        }
+    }
+
+    private static func decodeLenient(from value: AnyCodable) -> DynamicValue {
+        switch value {
+        case .string(let s): return .string(s)
+        case .number(let n): return .number(n)
+        case .bool(let b): return .bool(b)
+        case .array(let arr): return .array(arr)
+        case .dictionary(let dict):
+            if let path = dict["path"]?.stringValue, dict.count == 1 {
+                return .dataBinding(path: path)
+            }
+            if let callName = dict["call"]?.stringValue {
+                let args = dict["args"]?.dictionaryValue ?? [:]
+                let returnType = dict["returnType"]?.stringValue.flatMap(FunctionCallReturnType.init(rawValue:))
+                return .functionCall(FunctionCall(call: callName, args: args, returnType: returnType))
+            }
+            return .string("")
+        case .null:
+            return .string("")
         }
     }
 
@@ -206,17 +309,45 @@ public enum Action: Codable, Sendable {
             ))
         }
 
+        let allowedTopLevelKeys: Set<String> = ["event", "functionCall"]
+        let extraTopLevelKeys = Set(dict.keys).subtracting(allowedTopLevelKeys)
+        guard extraTopLevelKeys.isEmpty else {
+            throw schemaDecodingError(
+                at: decoder.codingPath,
+                "Action contains unsupported properties: \(extraTopLevelKeys.sorted().joined(separator: ", "))."
+            )
+        }
+
+        let hasEvent = dict["event"] != nil
+        let hasFunctionCall = dict["functionCall"] != nil
+        guard hasEvent != hasFunctionCall else {
+            throw schemaDecodingError(at: decoder.codingPath, "Action must contain exactly one of 'event' or 'functionCall'.")
+        }
+
         if let eventDict = dict["event"]?.dictionaryValue,
            let name = eventDict["name"]?.stringValue {
+            let allowedEventKeys: Set<String> = ["name", "context"]
+            let extraEventKeys = Set(eventDict.keys).subtracting(allowedEventKeys)
+            guard extraEventKeys.isEmpty else {
+                throw schemaDecodingError(
+                    at: decoder.codingPath,
+                    "Action event contains unsupported properties: \(extraEventKeys.sorted().joined(separator: ", "))."
+                )
+            }
             var ctx: [String: DynamicValue]?
             if let ctxDict = eventDict["context"]?.dictionaryValue {
-                ctx = ctxDict.mapValues { DynamicValue(from: $0) }
+                ctx = try ctxDict.reduce(into: [:]) { result, item in
+                    result[item.key] = try DynamicValue.decodeStrict(from: item.value, codingPath: decoder.codingPath)
+                }
+            } else if eventDict["context"] != nil {
+                throw schemaDecodingError(at: decoder.codingPath, "Action event 'context' must be an object.")
             }
             self = .event(name: name, context: ctx)
         } else if let fcDict = dict["functionCall"]?.dictionaryValue,
-                  let resolved = DynamicDictResolver.resolve(fcDict),
-                  case .functionCall(let fc) = resolved {
+                  case .functionCall(let fc) = try DynamicDictResolver.resolve(fcDict, codingPath: decoder.codingPath) {
             self = .functionCall(fc)
+        } else if dict["functionCall"] != nil {
+            throw schemaDecodingError(at: decoder.codingPath, "Action 'functionCall' must be a valid FunctionCall object.")
         } else {
             throw DecodingError.dataCorrupted(.init(
                 codingPath: decoder.codingPath,
@@ -239,8 +370,10 @@ public enum Action: Codable, Sendable {
             }
             self = .event(name: name, context: ctx)
         } else if let fcDict = dict["functionCall"]?.dictionaryValue,
-                  let resolved = DynamicDictResolver.resolve(fcDict),
-                  case .functionCall(let fc) = resolved {
+                  let callName = fcDict["call"]?.stringValue {
+            let args = fcDict["args"]?.dictionaryValue ?? [:]
+            let returnType = fcDict["returnType"]?.stringValue.flatMap(FunctionCallReturnType.init(rawValue:))
+            let fc = FunctionCall(call: callName, args: args, returnType: returnType)
             self = .functionCall(fc)
         } else {
             self = .event(name: "", context: nil)
@@ -278,8 +411,24 @@ public enum ChildList: Codable, Sendable {
         let raw = try AnyCodable(from: decoder)
         switch raw {
         case .array(let items):
-            self = .staticList(items.compactMap(\.stringValue))
+            var componentIds: [String] = []
+            componentIds.reserveCapacity(items.count)
+            for item in items {
+                guard let componentId = item.stringValue else {
+                    throw schemaDecodingError(at: decoder.codingPath, "ChildList array items must all be strings.")
+                }
+                componentIds.append(componentId)
+            }
+            self = .staticList(componentIds)
         case .dictionary(let dict):
+            let allowedKeys: Set<String> = ["componentId", "path"]
+            let extraKeys = Set(dict.keys).subtracting(allowedKeys)
+            guard extraKeys.isEmpty else {
+                throw schemaDecodingError(
+                    at: decoder.codingPath,
+                    "ChildList template contains unsupported properties: \(extraKeys.sorted().joined(separator: ", "))."
+                )
+            }
             guard let componentId = dict["componentId"]?.stringValue,
                   let path = dict["path"]?.stringValue else {
                 throw DecodingError.dataCorrupted(.init(
@@ -289,7 +438,7 @@ public enum ChildList: Codable, Sendable {
             }
             self = .template(componentId: componentId, path: path)
         default:
-            self = .staticList([])
+            throw schemaDecodingError(at: decoder.codingPath, "ChildList must be an array of component ids or a template object.")
         }
     }
 
@@ -314,5 +463,22 @@ public struct CheckRule: Codable, Sendable {
     public init(condition: DynamicBoolean, message: String) {
         self.condition = condition
         self.message = message
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case condition
+        case message
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        condition = try container.decode(DynamicBoolean.self, forKey: .condition)
+        message = try container.decode(String.self, forKey: .message)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(condition, forKey: .condition)
+        try container.encode(message, forKey: .message)
     }
 }

--- a/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
@@ -14,6 +14,13 @@
 
 import Foundation
 
+private func invalidEnumValueError<T>(for type: T.Type, rawValue: String, codingPath: [any CodingKey]) -> DecodingError {
+    DecodingError.dataCorrupted(.init(
+        codingPath: codingPath,
+        debugDescription: "Invalid \(type) value '\(rawValue)' for v0.9 schema."
+    ))
+}
+
 /// All standard A2UI v0.9 component types, plus `.custom` for extensions.
 public enum ComponentType: Hashable {
     case Text, Image, Icon, Video, AudioPlayer
@@ -52,7 +59,6 @@ public enum ComponentType: Hashable {
 /// Text variant: h1–h5, caption, body.
 public enum TextVariant: Codable, Hashable {
     case h1, h2, h3, h4, h5, caption, body
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -64,7 +70,7 @@ public enum TextVariant: Codable, Hashable {
         case "h5": self = .h5
         case "caption": self = .caption
         case "body": self = .body
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -82,7 +88,6 @@ public enum TextVariant: Codable, Hashable {
         case .h5: return "h5"
         case .caption: return "caption"
         case .body: return "body"
-        case .unknown(let s): return s
         }
     }
 }
@@ -90,7 +95,6 @@ public enum TextVariant: Codable, Hashable {
 /// Image fit mode.
 public enum ImageFit: Codable, Hashable {
     case contain, cover, fill, none, scaleDown
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -99,8 +103,8 @@ public enum ImageFit: Codable, Hashable {
         case "cover": self = .cover
         case "fill": self = .fill
         case "none": self = .none
-        case "scaleDown", "scale-down": self = .scaleDown
-        default: self = .unknown(raw)
+        case "scaleDown": self = .scaleDown
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -116,7 +120,6 @@ public enum ImageFit: Codable, Hashable {
         case .fill: return "fill"
         case .none: return "none"
         case .scaleDown: return "scaleDown"
-        case .unknown(let s): return s
         }
     }
 }
@@ -124,7 +127,6 @@ public enum ImageFit: Codable, Hashable {
 /// Image variant.
 public enum ImageVariant: Codable, Hashable {
     case icon, avatar, smallFeature, mediumFeature, largeFeature, header
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -135,7 +137,7 @@ public enum ImageVariant: Codable, Hashable {
         case "mediumFeature": self = .mediumFeature
         case "largeFeature": self = .largeFeature
         case "header": self = .header
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -152,7 +154,6 @@ public enum ImageVariant: Codable, Hashable {
         case .mediumFeature: return "mediumFeature"
         case .largeFeature: return "largeFeature"
         case .header: return "header"
-        case .unknown(let s): return s
         }
     }
 }
@@ -160,7 +161,6 @@ public enum ImageVariant: Codable, Hashable {
 /// Justify mode for Row/Column (maps to CSS justify-content).
 public enum Justify: Codable, Hashable {
     case start, center, end, spaceBetween, spaceAround, spaceEvenly, stretch
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -172,7 +172,7 @@ public enum Justify: Codable, Hashable {
         case "spaceAround": self = .spaceAround
         case "spaceEvenly": self = .spaceEvenly
         case "stretch": self = .stretch
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -190,7 +190,6 @@ public enum Justify: Codable, Hashable {
         case .spaceAround: return "spaceAround"
         case .spaceEvenly: return "spaceEvenly"
         case .stretch: return "stretch"
-        case .unknown(let s): return s
         }
     }
 }
@@ -198,7 +197,6 @@ public enum Justify: Codable, Hashable {
 /// Align mode for Row/Column/List (maps to CSS align-items).
 public enum Align: Codable, Hashable {
     case start, center, end, stretch
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -207,7 +205,7 @@ public enum Align: Codable, Hashable {
         case "center": self = .center
         case "end": self = .end
         case "stretch": self = .stretch
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -222,7 +220,6 @@ public enum Align: Codable, Hashable {
         case .center: return "center"
         case .end: return "end"
         case .stretch: return "stretch"
-        case .unknown(let s): return s
         }
     }
 }
@@ -230,14 +227,13 @@ public enum Align: Codable, Hashable {
 /// List direction.
 public enum ListDirection: Codable, Hashable {
     case vertical, horizontal
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         switch raw {
         case "vertical": self = .vertical
         case "horizontal": self = .horizontal
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -250,7 +246,6 @@ public enum ListDirection: Codable, Hashable {
         switch self {
         case .vertical: return "vertical"
         case .horizontal: return "horizontal"
-        case .unknown(let s): return s
         }
     }
 }
@@ -258,14 +253,13 @@ public enum ListDirection: Codable, Hashable {
 /// Divider axis.
 public enum DividerAxis: Codable, Hashable {
     case horizontal, vertical
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         switch raw {
         case "horizontal": self = .horizontal
         case "vertical": self = .vertical
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -278,7 +272,6 @@ public enum DividerAxis: Codable, Hashable {
         switch self {
         case .horizontal: return "horizontal"
         case .vertical: return "vertical"
-        case .unknown(let s): return s
         }
     }
 }
@@ -286,7 +279,6 @@ public enum DividerAxis: Codable, Hashable {
 /// Button variant.
 public enum ButtonVariant_Enum: Codable, Hashable {
     case `default`, primary, borderless
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -294,7 +286,7 @@ public enum ButtonVariant_Enum: Codable, Hashable {
         case "default": self = .default
         case "primary": self = .primary
         case "borderless": self = .borderless
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -308,7 +300,6 @@ public enum ButtonVariant_Enum: Codable, Hashable {
         case .default: return "default"
         case .primary: return "primary"
         case .borderless: return "borderless"
-        case .unknown(let s): return s
         }
     }
 }
@@ -316,7 +307,6 @@ public enum ButtonVariant_Enum: Codable, Hashable {
 /// TextField variant.
 public enum TextFieldVariant: Codable, Hashable {
     case shortText, longText, number, obscured
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
@@ -325,7 +315,7 @@ public enum TextFieldVariant: Codable, Hashable {
         case "longText": self = .longText
         case "number": self = .number
         case "obscured": self = .obscured
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -340,7 +330,6 @@ public enum TextFieldVariant: Codable, Hashable {
         case .longText: return "longText"
         case .number: return "number"
         case .obscured: return "obscured"
-        case .unknown(let s): return s
         }
     }
 }
@@ -348,14 +337,13 @@ public enum TextFieldVariant: Codable, Hashable {
 /// ChoicePicker variant.
 public enum ChoicePickerVariant: Codable, Hashable {
     case multipleSelection, mutuallyExclusive
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         switch raw {
         case "multipleSelection": self = .multipleSelection
         case "mutuallyExclusive": self = .mutuallyExclusive
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -368,7 +356,6 @@ public enum ChoicePickerVariant: Codable, Hashable {
         switch self {
         case .multipleSelection: return "multipleSelection"
         case .mutuallyExclusive: return "mutuallyExclusive"
-        case .unknown(let s): return s
         }
     }
 }
@@ -376,14 +363,13 @@ public enum ChoicePickerVariant: Codable, Hashable {
 /// ChoicePicker display style.
 public enum ChoicePickerDisplayStyle: Codable, Hashable {
     case checkbox, chips
-    case unknown(String)
 
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         switch raw {
         case "checkbox": self = .checkbox
         case "chips": self = .chips
-        default: self = .unknown(raw)
+        default: throw invalidEnumValueError(for: Self.self, rawValue: raw, codingPath: decoder.codingPath)
         }
     }
 
@@ -396,7 +382,6 @@ public enum ChoicePickerDisplayStyle: Codable, Hashable {
         switch self {
         case .checkbox: return "checkbox"
         case .chips: return "chips"
-        case .unknown(let s): return s
         }
     }
 }

--- a/Sources/A2UISwiftCore/Schema/ServerToClient.swift
+++ b/Sources/A2UISwiftCore/Schema/ServerToClient.swift
@@ -38,11 +38,40 @@ public enum A2uiMessage: Codable, Sendable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let raw = try AnyCodable(from: decoder)
+        guard case .dictionary(let dict) = raw else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "A2uiMessage must be a JSON object."
+            ))
+        }
+
+        let allowedKeys: Set<String> = ["version", "createSurface", "updateComponents", "updateDataModel", "deleteSurface"]
+        let extraKeys = Set(dict.keys).subtracting(allowedKeys)
+        guard extraKeys.isEmpty else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Message contains unsupported properties: \(extraKeys.sorted().joined(separator: ", "))."
+            ))
+        }
+
+        guard dict["version"]?.stringValue == "v0.9" else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: decoder.codingPath,
+                debugDescription: "Message version must be 'v0.9'."
+            ))
+        }
+
+        let data = try JSONEncoder().encode(raw)
+        let container = try JSONDecoder().decode(DecodedMessage.self, from: data)
 
         // Validate: only one update-type key is allowed per message.
-        let updateTypeKeys: [CodingKeys] = [.createSurface, .updateComponents, .updateDataModel, .deleteSurface]
-        let presentKeys = updateTypeKeys.filter { container.contains($0) }
+        let presentKeys = [
+            container.createSurface != nil ? CodingKeys.createSurface : nil,
+            container.updateComponents != nil ? CodingKeys.updateComponents : nil,
+            container.updateDataModel != nil ? CodingKeys.updateDataModel : nil,
+            container.deleteSurface != nil ? CodingKeys.deleteSurface : nil,
+        ].compactMap { $0 }
         if presentKeys.count > 1 {
             let names = presentKeys.map(\.stringValue).joined(separator: ", ")
             throw DecodingError.dataCorrupted(.init(
@@ -51,13 +80,13 @@ public enum A2uiMessage: Codable, Sendable {
             ))
         }
 
-        if let payload = try container.decodeIfPresent(CreateSurfacePayload.self, forKey: .createSurface) {
+        if let payload = container.createSurface {
             self = .createSurface(payload)
-        } else if let payload = try container.decodeIfPresent(UpdateComponentsPayload.self, forKey: .updateComponents) {
+        } else if let payload = container.updateComponents {
             self = .updateComponents(payload)
-        } else if let payload = try container.decodeIfPresent(UpdateDataModelPayload.self, forKey: .updateDataModel) {
+        } else if let payload = container.updateDataModel {
             self = .updateDataModel(payload)
-        } else if let payload = try container.decodeIfPresent(DeleteSurfacePayload.self, forKey: .deleteSurface) {
+        } else if let payload = container.deleteSurface {
             self = .deleteSurface(payload)
         } else {
             throw DecodingError.dataCorrupted(.init(
@@ -76,6 +105,14 @@ public enum A2uiMessage: Codable, Sendable {
         case .updateDataModel(let payload): try container.encode(payload, forKey: .updateDataModel)
         case .deleteSurface(let payload):   try container.encode(payload, forKey: .deleteSurface)
         }
+    }
+
+    private struct DecodedMessage: Codable {
+        let version: String
+        let createSurface: CreateSurfacePayload?
+        let updateComponents: UpdateComponentsPayload?
+        let updateDataModel: UpdateDataModelPayload?
+        let deleteSurface: DeleteSurfacePayload?
     }
 }
 

--- a/Sources/A2UISwiftUI/Views/Components/A2UIImage.swift
+++ b/Sources/A2UISwiftUI/Views/Components/A2UIImage.swift
@@ -128,7 +128,7 @@ struct A2UIImage: View {
             return FlexibleSizing(maxHeight: 400)
         case .header:
             return FlexibleSizing(fixedHeight: 200)
-        case .mediumFeature, .none, .some(.unknown):
+        case .mediumFeature, .none:
             return FlexibleSizing()
         }
     }

--- a/Tests/A2UISwiftCoreTests/Schema/VerifySchemaTests.swift
+++ b/Tests/A2UISwiftCoreTests/Schema/VerifySchemaTests.swift
@@ -12,27 +12,122 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Mirrors WebCore schema/verify-schema.test.ts
-//
-// WebCore's verify-schema test uses `zod-to-json-schema` to convert Zod schema
-// definitions (A2uiMessageSchema, CreateSurfaceMessageSchema, etc.) into JSON
-// Schema objects, then performs a structural diff against the official JSON
-// specification files on disk (specification/v0_9/json/*.json). It verifies
-// that every field name and type in the Zod schema matches the specification.
-//
-// This test has no Swift equivalent for the following reasons:
-//
-// 1. No Zod / zod-to-json-schema in Swift:
-//    Swift uses Codable (Decodable/Encodable) for schema definition. There is no
-//    runtime schema-to-JSON-Schema conversion library in Swift, so there is no
-//    programmatic way to extract a JSON Schema from Swift types.
-//
-// 2. Different validation strategy:
-//    Swift's Codable is validated at compile time by the type system. The
-//    equivalent assurance that Swift types match the specification is provided
-//    by the round-trip decode/encode tests in ClientToServerTests.swift and
-//    manual code review — not by a runtime schema diff.
-//
-// This file exists solely to maintain file-level parity with WebCore.
-
 @testable import A2UISwiftCore
+import Foundation
+import Testing
+
+@Suite("Schema strictness")
+struct VerifySchemaTests {
+
+    private let decoder = JSONDecoder()
+
+    @Test("server-to-client rejects invalid version")
+    func serverToClientRejectsInvalidVersion() throws {
+        let json = #"{"version":"v0.8","deleteSurface":{"surfaceId":"s1"}}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(A2uiMessage.self, from: data)
+        }
+    }
+
+    @Test("client-to-server rejects invalid version")
+    func clientToServerRejectsInvalidVersion() throws {
+        let json = #"{"version":"v0.8","action":{"name":"submit","surfaceId":"s1","sourceComponentId":"c1","timestamp":"2026-01-01T00:00:00Z","context":{}}}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(A2uiClientMessage.self, from: data)
+        }
+    }
+
+    @Test("dynamic string rejects object with extra properties")
+    func dynamicStringRejectsExtraProperties() throws {
+        let json = #"{"path":"/title","extra":true}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(DynamicString.self, from: data)
+        }
+    }
+
+    @Test("dynamic string rejects function call with wrong return type")
+    func dynamicStringRejectsWrongReturnType() throws {
+        let json = #"{"call":"formatNumber","args":{"value":1},"returnType":"number"}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(DynamicString.self, from: data)
+        }
+    }
+
+    @Test("child list rejects invalid object shape")
+    func childListRejectsInvalidObjectShape() throws {
+        let json = #"{"componentId":"row","path":"/items","extra":"nope"}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(ChildList.self, from: data)
+        }
+    }
+
+    @Test("action rejects extra properties")
+    func actionRejectsExtraProperties() throws {
+        let json = #"{"event":{"name":"submit"},"extra":true}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(Action.self, from: data)
+        }
+    }
+
+    @Test("action event rejects context values outside dynamic value schema")
+    func actionRejectsInvalidContextValue() throws {
+        let json = #"{"event":{"name":"submit","context":{"payload":{"nested":1}}}}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(Action.self, from: data)
+        }
+    }
+
+    @Test("check rule rejects legacy function-call shape")
+    func checkRuleRejectsLegacyShape() throws {
+        let json = #"{"call":"required","args":{"value":{"path":"/email"}},"message":"Email is required"}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(CheckRule.self, from: data)
+        }
+    }
+
+    @Test("text properties reject unsupported variant enum")
+    func textPropertiesRejectUnsupportedVariant() throws {
+        let json = #"{"text":"Hello","variant":"headline"}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(TextProperties.self, from: data)
+        }
+    }
+
+    @Test("button properties reject unsupported variant enum")
+    func buttonPropertiesRejectUnsupportedVariant() throws {
+        let json = #"{"child":"label","variant":"danger","action":{"event":{"name":"tap"}}}"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(ButtonProperties.self, from: data)
+        }
+    }
+
+    @Test("raw component rejects non-object payload")
+    func rawComponentRejectsNonObjectPayload() throws {
+        let json = #"["not-an-object"]"#
+        let data = try #require(json.data(using: .utf8))
+
+        #expect(throws: Error.self) {
+            try decoder.decode(RawComponent.self, from: data)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TDD coverage for strict v0.9 schema decoding requirements
- reject invalid message versions, extra object properties, and unsupported enum values during decode
- make schema validation failures throw decoding errors instead of falling back silently

## Testing
- swift test
