### PR TITLE
feat: align locale support with WebCore PR #1427

### DIFF
--- a/Sources/A2UISwiftCore/BasicCatalog/Functions/BasicFunctions.swift
+++ b/Sources/A2UISwiftCore/BasicCatalog/Functions/BasicFunctions.swift
@@ -337,6 +337,18 @@ private func basicEmail(_ name: String, _ args: [String: AnyCodable], _ context:
 
 // MARK: - Formatting
 
+/// Resolves the locale to use for locale-sensitive functions.
+/// Mirrors WebCore fallback chain: context.locale → client default.
+private func resolveLocale(_ context: DataContext) -> Locale {
+    if let id = context.locale { return Locale(identifier: id) }
+    return Locale.current
+}
+
+/// Resolves the locale identifier string for ICU-level APIs (e.g. A2UIPluralRules).
+private func resolveLocaleIdentifier(_ context: DataContext) -> String {
+    context.locale ?? Locale.current.identifier
+}
+
 private func basicFormatString(_ name: String, _ args: [String: AnyCodable], _ context: DataContext) throws -> AnyCodable? {
     // z.coerce.string(): missing → throw (String(undefined) = "undefined" in JS,
     // but we treat missing as a server error and throw for early failure).
@@ -367,9 +379,10 @@ private func basicFormatString(_ name: String, _ args: [String: AnyCodable], _ c
 private func basicFormatNumber(_ name: String, _ args: [String: AnyCodable], _ context: DataContext) throws -> AnyCodable? {
     let value = try coerceDouble(args["value"], argName: "value", funcName: name)
     if value.isNaN { return .string("") }
+    // Mirrors WebCore: try locale-aware formatting, fall back to plain decimal on error.
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
-    formatter.locale = Locale.current
+    formatter.locale = resolveLocale(context)
     if let decimals = toDouble(args["decimals"]) {
         let d = Int(decimals)
         formatter.minimumFractionDigits = d
@@ -378,7 +391,14 @@ private func basicFormatNumber(_ name: String, _ args: [String: AnyCodable], _ c
     if let groupingVal = args["grouping"]?.boolValue {
         formatter.usesGroupingSeparator = groupingVal
     }
-    return .string(formatter.string(from: NSNumber(value: value)) ?? "")
+    if let result = formatter.string(from: NSNumber(value: value)) {
+        return .string(result)
+    }
+    // Fallback mirrors WebCore: `args.decimals !== undefined ? value.toFixed(decimals) : String(value)`
+    if let decimals = toDouble(args["decimals"]) {
+        return .string(String(format: "%.\(Int(decimals))f", value))
+    }
+    return .string(String(value))
 }
 
 private func basicFormatCurrency(_ name: String, _ args: [String: AnyCodable], _ context: DataContext) throws -> AnyCodable? {
@@ -387,7 +407,7 @@ private func basicFormatCurrency(_ name: String, _ args: [String: AnyCodable], _
     let currency = (try? coerceRequiredString(args["currency"], argName: "currency", funcName: name)) ?? "USD"
     let formatter = NumberFormatter()
     formatter.numberStyle = .currency
-    formatter.locale = Locale.current
+    formatter.locale = resolveLocale(context)
     formatter.currencyCode = currency
     if let decimals = toDouble(args["decimals"]) {
         let d = Int(decimals)
@@ -443,19 +463,33 @@ private func basicFormatDate(_ name: String, _ args: [String: AnyCodable], _ con
         }
     }
     let outputFormatter = DateFormatter()
-    outputFormatter.locale = Locale.current
+    // Mirrors the locale-sensitive approach used by formatNumber/formatCurrency/pluralize.
+    // WebCore's date-fns format() is inherently locale-neutral (always English patterns),
+    // so the PR didn't change formatDate. But Swift's DateFormatter IS locale-sensitive —
+    // patterns like "MMMM" produce different month names per locale — so we must respect
+    // context.locale here to maintain consistency across all locale-sensitive functions.
+    outputFormatter.locale = resolveLocale(context)
     outputFormatter.dateFormat = formatStr
     return .string(outputFormatter.string(from: parsedDate))
 }
 
 // WebCore `PluralizeImplementation`:
-//   const rule = new Intl.PluralRules('en-US').select(args.value);
-//   return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
+//   try {
+//     const rule = getPluralRules(context.locale).select(args.value);
+//     return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
+//   } catch (e) {
+//     console.warn('Error in pluralize:', e);
+//     return String(args.other ?? '');
+//   }
 private func basicPluralize(_ name: String, _ args: [String: AnyCodable], _ context: DataContext) throws -> AnyCodable? {
     let value = try coerceDouble(args["value"], argName: "value", funcName: name)
     _ = try coerceRequiredString(args["other"], argName: "other", funcName: name)
-    let rule = A2UIPluralRules(localeIdentifier: "en-US").select(value)
-    return .string(toString(args[rule]) ?? toString(args["other"]) ?? "")
+    // Mirrors WebCore: try locale-aware plural selection, fall back to `other` on error.
+    let rule = A2UIPluralRules(localeIdentifier: resolveLocaleIdentifier(context)).select(value)
+    if let matched = toString(args[rule]) {
+        return .string(matched)
+    }
+    return .string(toString(args["other"]) ?? "")
 }
 
 private func basicOpenUrl(_ name: String, _ args: [String: AnyCodable], _ context: DataContext) throws -> AnyCodable? {

--- a/Sources/A2UISwiftCore/Rendering/DataContext.swift
+++ b/Sources/A2UISwiftCore/Rendering/DataContext.swift
@@ -104,6 +104,12 @@ public final class DataContext {
         self.functionInvoker = surface.catalog.invoker
     }
 
+    /// The locale for this context, inherited from the surface.
+    /// Mirrors WebCore `DataContext.locale`.
+    public var locale: String? {
+        surface.locale
+    }
+
     // MARK: - resolvePath
 
     /// Resolves a path: absolute paths pass through; relative paths are joined with the base path.

--- a/Sources/A2UISwiftCore/State/SurfaceModel.swift
+++ b/Sources/A2UISwiftCore/State/SurfaceModel.swift
@@ -27,6 +27,10 @@ public final class SurfaceModel: Identifiable {
     public let catalog: Catalog
     public let theme: AnyCodable?
     public let sendDataModel: Bool
+    /// The locale to use in locale-sensitive functions (BCP 47, e.g. "en-US", "pl", "ar").
+    /// When nil, functions fall back to the client's current locale.
+    /// Mirrors WebCore `SurfaceModel.locale`.
+    public let locale: String?
 
     public let dataModel: DataModel
     public let componentsModel: SurfaceComponentsModel
@@ -51,13 +55,15 @@ public final class SurfaceModel: Identifiable {
         id: String,
         catalog: Catalog,
         theme: AnyCodable? = nil,
-        sendDataModel: Bool = false
+        sendDataModel: Bool = false,
+        locale: String? = nil
     ) {
         self.id = id
         self.catalog = catalog
         self.catalogId = catalog.id
         self.theme = theme
         self.sendDataModel = sendDataModel
+        self.locale = locale
         self.dataModel = DataModel()
         self.componentsModel = SurfaceComponentsModel()
     }
@@ -67,13 +73,15 @@ public final class SurfaceModel: Identifiable {
         id: String,
         catalogId: String = "",
         theme: AnyCodable? = nil,
-        sendDataModel: Bool = false
+        sendDataModel: Bool = false,
+        locale: String? = nil
     ) {
         self.init(
             id: id,
             catalog: Catalog(id: catalogId),
             theme: theme,
-            sendDataModel: sendDataModel
+            sendDataModel: sendDataModel,
+            locale: locale
         )
     }
 

--- a/Tests/A2UISwiftCoreTests/BasicCatalog/A2UIPluralRulesTests.swift
+++ b/Tests/A2UISwiftCoreTests/BasicCatalog/A2UIPluralRulesTests.swift
@@ -178,4 +178,27 @@ struct A2UIPluralRulesTests {
         #expect(rules.select(Double.infinity) == "other")
         #expect(rules.select(-Double.infinity) == "other")
     }
+
+    // Verify ICU C API accepts both BCP-47 (hyphen) and POSIX/ICU (underscore) formats.
+    // BCP-47 comes from the server / host app (WebCore convention).
+    // ICU underscore format comes from Locale.current.identifier (Apple fallback).
+    @Test(
+        "ICU accepts both BCP-47 and POSIX locale identifiers",
+        arguments: [
+            ("en-US", "en_US", 1.0, "one"),
+            ("en-US", "en_US", 2.0, "other"),
+            ("pl",    "pl",    2.0, "few"),
+            ("pl",    "pl",    5.0, "many"),
+            ("ar",    "ar",    0.0, "zero"),
+            ("ar",    "ar",    2.0, "two"),
+            ("zh-CN", "zh_CN", 1.0, "other"),
+        ]
+    )
+    func bcp47VsIcu(bcp47: String, icu: String, number: Double, want: String) {
+        let fromBcp47 = A2UIPluralRules(localeIdentifier: bcp47).select(number)
+        let fromIcu   = A2UIPluralRules(localeIdentifier: icu).select(number)
+        #expect(fromBcp47 == want)
+        #expect(fromIcu == want)
+        #expect(fromBcp47 == fromIcu)
+    }
 }

--- a/Tests/A2UISwiftCoreTests/BasicCatalog/BasicFunctionsTests.swift
+++ b/Tests/A2UISwiftCoreTests/BasicCatalog/BasicFunctionsTests.swift
@@ -20,9 +20,9 @@ import Foundation
 
 // MARK: - Test Fixtures
 
-private func makeContext() throws -> (catalog: Catalog, context: DataContext) {
+private func makeContext(locale: String? = nil) throws -> (catalog: Catalog, context: DataContext) {
     let catalog = Catalog(id: "basic", functions: BASIC_FUNCTIONS)
-    let surface = SurfaceModel(id: "s1", catalog: catalog)
+    let surface = SurfaceModel(id: "s1", catalog: catalog, locale: locale)
     try surface.dataModel.set("/", value: .dictionary(["a": .number(10), "b": .number(20)]))
     let context = DataContext(surface: surface, path: "/")
     return (catalog, context)
@@ -587,6 +587,64 @@ struct BasicFunctionsTests {
             } else {
                 Issue.record("Expected a string result from formatCurrency with invalid currency code")
             }
+        }
+
+        // MARK: - Pluralize
+
+        @Test("pluralize selects correct plural form (en-US default)")
+        func pluralizeDefault() throws {
+            let (catalog, context) = try makeContext()
+            #expect(
+                try invoke("pluralize", ["value": .number(1), "one": .string("apple"), "other": .string("apples")], catalog: catalog, context: context)
+                == .string("apple")
+            )
+            #expect(
+                try invoke("pluralize", ["value": .number(5), "one": .string("apple"), "other": .string("apples")], catalog: catalog, context: context)
+                == .string("apples")
+            )
+        }
+
+        // Mirrors WebCore test: "pluralize with Welsh locale"
+        // Welsh (cy) exercises all 6 CLDR plural categories.
+        @Test("pluralize with Welsh locale")
+        func pluralizeWelsh() throws {
+            let (catalog, context) = try makeContext(locale: "cy")
+            // Welsh for various numbers of "cat"
+            let args: [String: AnyCodable] = [
+                "zero": .string("cathod"),
+                "one": .string("gath"),
+                "two": .string("gath"),
+                "few": .string("cath"),
+                "many": .string("chath"),
+                "other": .string("cath"),
+            ]
+            #expect(try invoke("pluralize", args.merging(["value": .number(0)]) { $1 }, catalog: catalog, context: context) == .string("cathod"))
+            #expect(try invoke("pluralize", args.merging(["value": .number(1)]) { $1 }, catalog: catalog, context: context) == .string("gath"))
+            #expect(try invoke("pluralize", args.merging(["value": .number(2)]) { $1 }, catalog: catalog, context: context) == .string("gath"))
+            #expect(try invoke("pluralize", args.merging(["value": .number(3)]) { $1 }, catalog: catalog, context: context) == .string("cath"))
+            #expect(try invoke("pluralize", args.merging(["value": .number(6)]) { $1 }, catalog: catalog, context: context) == .string("chath"))
+            #expect(try invoke("pluralize", args.merging(["value": .number(4)]) { $1 }, catalog: catalog, context: context) == .string("cath"))
+        }
+
+        // Mirrors WebCore test: "pluralize fallback to other"
+        @Test("pluralize fallback to other")
+        func pluralizeFallback() throws {
+            let (catalog, context) = try makeContext()
+            // value=5 → "other" category, returns "apples"
+            #expect(
+                try invoke("pluralize", ["value": .number(5), "one": .string("apple"), "other": .string("apples")], catalog: catalog, context: context)
+                == .string("apples")
+            )
+            // value=1 → "one" category, but no "one" key → falls back to "other"
+            #expect(
+                try invoke("pluralize", ["value": .number(1), "other": .string("apples")], catalog: catalog, context: context)
+                == .string("apples")
+            )
+            // value=0 → "other" category in en-US, returns "apples"
+            #expect(
+                try invoke("pluralize", ["value": .number(0), "other": .string("apples")], catalog: catalog, context: context)
+                == .string("apples")
+            )
         }
     }
 

--- a/Tests/A2UISwiftCoreTests/Test/TestUtils.swift
+++ b/Tests/A2UISwiftCoreTests/Test/TestUtils.swift
@@ -61,10 +61,11 @@ func createTestContext(
 func createTestDataContext(
     data: [String: AnyCodable] = [:],
     path: String = "/",
-    functions: [String: FunctionInvoker] = [:]
+    functions: [String: FunctionInvoker] = [:],
+    locale: String? = nil
 ) -> DataContext {
     let catalog = Catalog(id: "test-catalog", functions: functions)
-    let surface = SurfaceModel(id: "test", catalog: catalog)
+    let surface = SurfaceModel(id: "test", catalog: catalog, locale: locale)
     if !data.isEmpty {
         try! surface.dataModel.set("/", value: .dictionary(data))
     }
@@ -77,9 +78,9 @@ func createTestDataContext(
 // data-context.test.ts: creates a bare SurfaceModel pre-loaded with
 // optional data, for direct use in DataContext construction.
 
-func makeSurface(data: [String: AnyCodable] = [:]) -> SurfaceModel {
+func makeSurface(data: [String: AnyCodable] = [:], locale: String? = nil) -> SurfaceModel {
     let catalog = Catalog(id: "test-catalog")
-    let surface = SurfaceModel(id: "test", catalog: catalog)
+    let surface = SurfaceModel(id: "test", catalog: catalog, locale: locale)
     if !data.isEmpty {
         try! surface.dataModel.set("/", value: .dictionary(data))
     }


### PR DESCRIPTION
## Summary

对齐官方 WebCore commit [`83a395c9`](https://github.com/google/A2UI/commit/83a395c9) (PR [google/A2UI#1427](https://github.com/google/A2UI/pull/1427))，解决 [google/A2UI#1385](https://github.com/google/A2UI/issues/1385) 和 [flutter/genui#902](https://github.com/flutter/genui/issues/902) 中的 locale 问题。

### 核心改动

- **`SurfaceModel`** 新增 `locale: String?` 属性，宿主 App 可在创建 surface 时传入 BCP-47 locale（如 `"pl"`、`"ar-SA"`）
- **`DataContext`** 新增 `locale` computed property，从 surface 继承
- **`pluralize`** — 从硬编码 `"en-US"` 改为 `context.locale`，nil 时 fallback 到 `Locale.current`
- **`formatNumber` / `formatCurrency`** — 同上（原本用的 `Locale.current`，现在优先 `context.locale`）
- **`formatDate`** — 也改为尊重 `context.locale`（WebCore 没改是因为 date-fns 天然 locale-neutral，但 Swift 的 `DateFormatter` 是 locale-sensitive 的，`"MMMM"` 等 pattern 在不同 locale 下产出不同语言的月份名，不改会导致四个 locale-sensitive 函数中只有这一个不跟 context locale 走）

### Locale 标识符格式兼容性

WebCore 传递 BCP-47 格式（`"en-US"`），而 Swift 的 `Locale.current.identifier` 返回 ICU/POSIX 格式（`"en_US"`）。这两个体系在 API 入口均兼容：

| API | BCP-47 `"en-US"` | ICU `"en_US"` |
|---|---|---|
| `Locale(identifier:)` | ✅ | ✅ |
| `NumberFormatter` | ✅ | ✅ |
| ICU C API (`uplrules_openForType`) | ✅ | ✅ |

新增 `"ICU accepts both BCP-47 and POSIX locale identifiers"` 测试用例，验证两种格式在 `A2UIPluralRules` 中产出完全一致的 plural category。

### 与 WebCore PR 的差异说明

| WebCore PR 改动 | Swift 实现 | 说明 |
|---|---|---|
| `SurfaceModel` + `DataContext` 加 `locale` | ✅ 1:1 对应 | |
| `pluralize` / `formatNumber` / `formatCurrency` 用 `context.locale` | ✅ 1:1 对应 | |
| `formatDate` 未改 | ⚠️ Swift 额外改了 | date-fns 天然 locale-neutral 所以 WebCore 不需要改；Swift `DateFormatter` 天然 locale-sensitive，必须改才能保持四个函数行为一致 |
| `Intl` 实例缓存 (`numberFormatCache` 等) | 不搬 | JS `Intl.NumberFormat` 构造开销高；Swift `NumberFormatter` 轻量、`A2UIPluralRules` 是 struct 直接调 ICU C API |
| 移除 `.passthrough()` | N/A | Zod schema 专属 |
| `console.warn` 日志 | 不搬 | Swift 端错误通过 `dispatchError` 链路传递 |

### 注意

`locale` 不是 v0.9 SPEC 中 `createSurface` 的协议字段（schema 里有 `additionalProperties: false`），而是 **renderer SDK 层面的 API**——由宿主 App 在构造 `SurfaceModel` 时传入，与 WebCore 的设计一致。

## Test plan

- [x] 302 tests, 54 suites 全部通过
- [x] `pluralize` Welsh locale 测试覆盖全部 6 个 CLDR plural category (zero/one/two/few/many/other)
- [x] `pluralize` fallback to `other` 测试
- [x] BCP-47 vs ICU/POSIX locale identifier 一致性测试
- [x] 既有 `formatNumber` / `formatCurrency` / `formatDate` 测试回归通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)