### PR TITLE
perf(A2UISwiftUI): keyed reconciliation in updateTreeInPlace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,106 +1,120 @@
 # AGENTS.md
 
-Instructions for AI coding agents working in this repository.
+Instructions for AI coding agents working in this repository. (Mirrors `CLAUDE.md` — keep the two in sync when editing either.)
 
-## What this project is
+## What this is
 
-A SwiftUI renderer for the [A2UI protocol](https://github.com/google/A2UI). It takes `ServerToClientMessage` JSON streams from AI agents and renders them as fully native Apple platform UIs. The public surface is one view: `A2UIRendererView`.
+Swift renderer for the [A2UI protocol](https://github.com/google/A2UI) — converts JSON UI descriptions streamed from AI agents into native Apple UI. SwiftUI is the feature-complete renderer; UIKit and AppKit are in development. The current spec version is **v0.9**; v0.8 lives in the deprecated `v_08` module and should not be extended.
 
 ## Commands
 
 ```bash
-swift test                          # run all tests (must pass with 0 failures)
-swift test --filter <TestName>      # run a single test class
-open A2UIDemoApp/A2UIDemoApp.xcodeproj  # open demo app in Xcode
+swift test                                                # run all tests
+swift test --filter A2UISwiftUITests                      # run one test target
+swift test --filter SurfaceViewModelTests                 # run one test class
+swift test --filter SurfaceViewModelTests/testFoo         # run one test method
+swift build                                               # build all targets
+./build-docc.sh                                           # build DocC for all targets (macOS)
 ```
 
-No build script. No Makefile. No dependencies beyond the Swift toolchain and Apple SDKs.
+No Makefile. Only external dependency is `swift-foundation-icu` (used by `A2UISwiftCore` for ICU pluralization). Min platforms: iOS 17 / macOS 14 / tvOS 17 / watchOS 10 / visionOS 1.
 
-## Architecture
+## Module layout
+
+Six SPM library products, organized by concern. Cross-module dependencies are explicit in `Package.swift` — respect them.
+
+| Module | Depends on | What it owns |
+|---|---|---|
+| `Primitives` | — | Shared value types used across SDKs: `ChatMessage`, `Part`, `JSONValue`, `ToolDefinition` |
+| `A2UISwiftCore` | `_FoundationICU` | **v0.9 protocol layer** — schema, data model, catalogs, expression evaluator, message processor, transport. UI-framework-agnostic. |
+| `A2UISwiftUI` | `A2UISwiftCore` | v0.9 SwiftUI renderer (`A2UISurfaceView`, `SurfaceViewModel`) |
+| `A2UIUIKit` | `A2UISwiftCore` | v0.9 UIKit renderer (iOS/tvOS/visionOS) — community extension via `A2UIUIKitComponent` |
+| `A2UIAppKit` | `A2UISwiftCore` | v0.9 AppKit renderer (macOS) — community extension via `A2UIAppKitComponent` |
+| `v_08` | — | **Deprecated** v0.8 renderer (`A2UIRendererView`, `SurfaceManager`). Bug-fix only; do not add features. |
+
+## v0.9 architecture
+
+The core insight: protocol logic (`A2UISwiftCore`) is fully decoupled from any UI framework. The SwiftUI/UIKit/AppKit renderers are thin layers on top of the same `SurfaceModel` + `ComponentNode` tree.
 
 ```
-A2UIRendererView          ← only public API (3 initializers)
-    └── SurfaceManager    ← @Observable, owns all surface state
-        └── SurfaceViewModel (per surface)
-            └── ComponentNode tree (pre-resolved, rebuilt on each update)
-                └── A2UIComponentView (recursive renderer, read-only)
-                    └── A2UI{Component}.swift (one file per component type)
+Agent JSON (JSONL stream)
+    │
+    ▼
+A2UITransport / A2UIStreamParser      ◄── Sources/A2UISwiftCore/Transport
+    │   (ServerToClientMessage values)
+    ▼
+MessageProcessor                       ◄── Sources/A2UISwiftCore/Processing
+    │   • routes createSurface / updateDataModel / updateComponents / etc.
+    │   • owns the SurfaceGroupModel (one per agent connection)
+    ▼
+SurfaceModel  ─── DataModel              ◄── PathSlot values (@Observable, per-path)
+    │         ─── SurfaceComponentsModel ◄── component definitions (RawComponent)
+    │
+    ▼
+SurfaceViewModel (SwiftUI-only)         ◄── Sources/A2UISwiftUI
+    │   • rebuilds the ComponentNode tree on updateComponents
+    │   • exposes @Observable componentTree
+    ▼
+A2UISurfaceView → A2UIComponentView (recursive switch on ComponentType)
+    │
+    ▼
+A2UI{Component}.swift   (one per component, read-only)
+    │   • reads props via dataContext.resolve(props.text)
+    │   • reads style via @Environment(\.a2uiStyle)
+    │   • reads/writes ui state on ComponentNode.uiState
 ```
 
-**Key invariant:** `A2UIComponentView` and all component views are read-only. They never mutate state directly. All tree mutations go through `SurfaceManager`.
+**Two update paths with very different granularity** — keep them straight:
 
-**UI state** (e.g., selected tab index, modal presentation) lives on `ComponentNode.uiState` — an `@Observable` object that is migrated by ID across tree rebuilds, so it survives `LazyVStack` recycling.
+| Path | Trigger | Observable surface | Re-render scope |
+|---|---|---|---|
+| **Data layer** | `updateDataModel` message | `PathSlot.value` (per path) | Only views that resolved that path |
+| **Structure layer** | `updateComponents` message | `ComponentNode.instance` / `componentTree` | The node whose `instance` changed (intended) |
 
-**Styling** flows through the SwiftUI `Environment` as `A2UIStyle`. Never pass style as an explicit parameter to component views.
+Touching either of these without understanding the SwiftUI observation it triggers will silently regress performance. Before assigning to an `@Observable` property, check whether the value actually changed — `@Observable` does not de-duplicate.
 
-## File map
+## Key types (Core)
 
-| Path | Purpose |
-|------|---------|
-| `Sources/A2UI/A2UIRenderer.swift` | Public API — `A2UIRendererView` |
-| `Sources/A2UI/Models/Messages.swift` | `ServerToClientMessage`, `ClientToServerMessage` |
-| `Sources/A2UI/Models/Components.swift` | `A2UIComponent` tagged union |
-| `Sources/A2UI/Models/ComponentTypes.swift` | Per-component `Codable` structs |
-| `Sources/A2UI/Models/Primitives.swift` | Shared value types (`Color`, `Action`, etc.) |
-| `Sources/A2UI/Processing/SurfaceManager.swift` | `@Observable` state, message processing |
-| `Sources/A2UI/Processing/JSONLStreamParser.swift` | Async JSONL → message stream |
-| `Sources/A2UI/Views/A2UIComponentView.swift` | Top-level component switch |
-| `Sources/A2UI/Views/Components/` | One `.swift` per component |
-| `Sources/A2UI/Views/Components/COMPONENT_DECISIONS.md` | Design rationale per component |
-| `Sources/A2UI/Styling/A2UIStyle.swift` | Theme system + Environment integration |
-| `Sources/A2UI/Networking/A2AClient.swift` | JSON-RPC over HTTP |
-| `Tests/A2UITests/` | 87 tests across 5 files |
+| File | Role |
+|---|---|
+| `Sources/A2UISwiftCore/State/SurfaceModel.swift` | Per-surface state container; owns `DataModel` + `SurfaceComponentsModel`; dispatches actions/errors via `EventEmitter`. Mirrors WebCore `SurfaceModel`. |
+| `Sources/A2UISwiftCore/State/DataModel.swift` | Path-keyed value store backing `PathSlot` |
+| `Sources/A2UISwiftCore/State/SurfaceGroupModel.swift` | Holds multiple surfaces for one agent connection |
+| `Sources/A2UISwiftCore/Rendering/ComponentNode.swift` | `@Observable` resolved tree node — `instance`, `weight`, `children`, `uiState` |
+| `Sources/A2UISwiftCore/Rendering/DataContext.swift` | View-side facade — `resolve(expr)` reads `PathSlot.value`; SwiftUI tracks the dependency automatically |
+| `Sources/A2UISwiftCore/Processing/MessageProcessor.swift` | Routes `ServerToClientMessage` → SurfaceModel mutations |
+| `Sources/A2UISwiftCore/Catalog/Types.swift` | `Catalog`, `FunctionInvoker` — what a renderer needs to invoke catalog functions |
+| `Sources/A2UISwiftCore/BasicCatalog/BasicCatalog.swift` | The standard 18-component + 25-function catalog; mirror of the React renderer's `basicCatalog` |
+| `Sources/A2UISwiftCore/Schema/ServerToClient.swift` | Decoders for incoming messages |
+| `Sources/A2UISwiftCore/Schema/RawComponentExtensions.swift` | `RawComponent.typedProperties<T>()` — decode flat v0.9 props into a struct |
+| `Sources/A2UISwiftCore/Transport/JsonBlockParser.swift` | Incremental JSONL → message parser used by streaming transports |
+
+Many comments in `A2UISwiftCore` reference the WebCore (TypeScript) reference renderer. When changing behavior here, check the cited WebCore method — this package intentionally mirrors it.
+
+## Adding or modifying a SwiftUI component
+
+1. **Catalog entry** — if it's a standard component, the `BASIC_COMPONENT_NAMES` list in `Sources/A2UISwiftCore/BasicCatalog/Components/BasicComponents.swift` already includes it. For custom components, register via `CustomComponentCatalog` / `CustomComponentRegistry` (see `Sources/A2UISwiftUI/`).
+2. **Typed props** — define a `Codable` struct and decode with `node.typedProperties(YourProps.self)`. All properties optional with sensible defaults.
+3. **View** — add `Sources/A2UISwiftUI/Views/Components/A2UIYourComponent.swift`. Read styling from `@Environment(\.a2uiStyle)`, resolve dynamic values via the surface's `DataContext`, and never mutate the tree from inside the view.
+4. **Wire** — add a `case` to `A2UIComponentView`.
+5. **Test** — add a test in `Tests/A2UISwiftUITests/` (UI/rendering) or `Tests/A2UISwiftCoreTests/` (protocol/decoding).
 
 ## Rules
 
-### Do
-- Use `@Observable` for any new state-holding types
-- Use `@Environment(\.a2uiStyle)` to read styling — never hardcode colors, padding, or corner radii
-- Use `#if os(watchOS)` / `#if os(tvOS)` for platform-specific fallbacks
-- Prefer system SwiftUI controls over custom drawing
-- Keep `A2UIComponentView` and child views read-only
-- Add an entry to `COMPONENT_DECISIONS.md` when making a non-obvious implementation choice
-- Write tests for every new decode path: happy path, missing optional fields, Codable round-trip
+- **Use `@Observable`** for any new observable state. Never `ObservableObject` / `@Published` / `@StateObject`.
+- **Guard assignments** before writing to an `@Observable` property. `existing.instance = new.instance` notifies SwiftUI even when the value is identical — check equality first when reconciling trees.
+- **No hardcoded numerics** (spacing, radii, font sizes, colors) in component views — pull from `A2UIStyle`.
+- **No `AnyView`** — use generics or `@ViewBuilder`.
+- **No third-party dependencies** other than what's already in `Package.swift` (`swift-foundation-icu`).
+- **Read-only component views.** All mutation goes through `SurfaceModel` / `SurfaceViewModel`. UI-only state lives on `ComponentNode.uiState`, which survives tree rebuilds (keyed by node id) so `LazyVStack` recycling is safe.
+- **Locale-sensitive code** in `BasicCatalog/Functions` must match WebCore's behavior — see PR refs in commits like `feat: align locale support with WebCore PR #1427`.
+- **Don't extend `v_08`.** New features land in the v0.9 modules.
+- **Platform fallbacks** — when a control is unavailable on watchOS/tvOS, provide a functional fallback (e.g., wheel picker instead of segmented, +/− buttons instead of slider). Never render nothing.
 
-### Don't
-- Use `ObservableObject` / `@StateObject` / `@Published` — this codebase uses `@Observable`
-- Use `AnyView` — use generics or `@ViewBuilder`
-- Add third-party dependencies
-- Hardcode any numeric values (spacing, radii, font sizes) — pull from `A2UIStyle`
-- Mutate component tree state from inside a view
-- Skip `swift test` before completing a task
+## Commit convention
 
-## Adding a component
+Repo uses [Conventional Commits](https://www.conventionalcommits.org/) — `cliff.toml` parses `feat:` / `fix:` / `perf:` / `refactor:` / `docs:` / `test:` / `ci:` into changelog sections. Releases are tagged `vX.Y.Z`; `.github/workflows/release.yml` auto-generates release notes via `git-cliff` on tag push.
 
-1. **Model** — add a `Codable` struct in `ComponentTypes.swift`. All properties optional with sensible defaults.
-2. **Register** — add a case to `A2UIComponent` in `Components.swift` and handle it in `init(from:)`.
-3. **View** — create `Sources/A2UI/Views/Components/A2UI{Name}.swift`. Follow the conventions above.
-4. **Wire** — add a `case` in `A2UIComponentView.renderComponent(_:)`.
-5. **Test** — add decode tests in `Tests/A2UITests/MessageDecodingTests.swift` or a new file.
-6. **Document** — add an entry to `COMPONENT_DECISIONS.md`.
+## Tests
 
-## Testing conventions
-
-Test files live in `Tests/A2UITests/`. JSON fixtures go in `Tests/A2UITests/TestData/`.
-
-Each test file has a clear scope:
-- `MessageDecodingTests.swift` — JSON → model decode
-- `DataBindingTests.swift` — data binding / path resolution
-- `PrimitivesTests.swift` — primitive value types
-- `MultipleChoiceLogicTests.swift` — selection logic
-- `TextFieldValidationTests.swift` — regex validation
-
-When adding tests, match the existing file structure. Prefer small, focused test functions over large ones. Use `XCTAssertEqual` rather than `XCTAssert` so failures show the actual vs expected values.
-
-## Platform support matrix
-
-| Feature | iOS | macOS | visionOS | watchOS | tvOS |
-|---------|-----|-------|----------|---------|------|
-| `@Observable` | ✅ 17+ | ✅ 14+ | ✅ 1+ | ✅ 10+ | ✅ 17+ |
-| `AVPlayerViewController` | ✅ | ❌ (use `AVPlayerView`) | ✅ | ❌ | ✅ |
-| `DatePicker` | ✅ | ✅ | ✅ | ✅ | ❌ (fallback: read-only text) |
-| `Slider` | ✅ | ✅ | ✅ | ✅ | ❌ (fallback: +/− buttons) |
-| `TextEditor` | ✅ | ✅ | ✅ | ❌ | ❌ |
-| `.segmented` Picker | ✅ | ✅ | ✅ | ❌ (fallback: `.wheel`) | ❌ |
-
-When a control is unavailable on a platform, provide a functional fallback — never silently render nothing.
+Six test targets, one per module. Tests live in `Tests/<ModuleName>Tests/`. Use `XCTAssertEqual` (shows actual vs expected on failure) over `XCTAssert`. When mirroring a WebCore test, name the test method to match so the correspondence is obvious.

--- a/Sources/A2UISwiftCore/Schema/CommonTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/CommonTypes.swift
@@ -46,7 +46,7 @@ public struct FunctionCall: Codable, Sendable, Equatable {
 // MARK: - LiteralDecodable protocol
 
 /// 让泛型 Dynamic<T> 知道如何从 AnyCodable 提取字面量，以及提供默认值。
-public protocol LiteralDecodable: Codable, Equatable {
+public protocol LiteralDecodable: Codable {
     static func fromAnyCodable(_ value: AnyCodable) -> Self?
     static var defaultLiteral: Self { get }
 }
@@ -77,7 +77,7 @@ extension Array: LiteralDecodable where Element == String {
 
 /// 泛型动态值：字面量 T | 数据绑定 | 函数调用。
 /// 一份 Codable 实现覆盖 DynamicString / DynamicNumber / DynamicBoolean / DynamicStringList。
-public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable, Equatable {
+public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable {
     
     case literal(T)
     case dataBinding(path: String)
@@ -109,6 +109,8 @@ public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable, Equatabl
         }
     }
 }
+
+extension Dynamic: Equatable where T: Equatable {}
 
 // MARK: - Type aliases
 

--- a/Sources/A2UISwiftCore/Schema/CommonTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/CommonTypes.swift
@@ -31,7 +31,7 @@ public enum FunctionCallReturnType: String, Codable, Sendable {
 
 /// A function call: `{"call":"name","args":{...},"returnType":"string"}`.
 /// Mirrors WebCore `FunctionCallSchema`.
-public struct FunctionCall: Codable, Sendable {
+public struct FunctionCall: Codable, Sendable, Equatable {
     public var call: String
     public var args: [String: AnyCodable]
     public var returnType: FunctionCallReturnType?
@@ -46,7 +46,7 @@ public struct FunctionCall: Codable, Sendable {
 // MARK: - LiteralDecodable protocol
 
 /// 让泛型 Dynamic<T> 知道如何从 AnyCodable 提取字面量，以及提供默认值。
-public protocol LiteralDecodable: Codable {
+public protocol LiteralDecodable: Codable, Equatable {
     static func fromAnyCodable(_ value: AnyCodable) -> Self?
     static var defaultLiteral: Self { get }
 }
@@ -77,7 +77,7 @@ extension Array: LiteralDecodable where Element == String {
 
 /// 泛型动态值：字面量 T | 数据绑定 | 函数调用。
 /// 一份 Codable 实现覆盖 DynamicString / DynamicNumber / DynamicBoolean / DynamicStringList。
-public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable {
+public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable, Equatable {
     
     case literal(T)
     case dataBinding(path: String)

--- a/Sources/A2UISwiftCore/Schema/RawComponentExtensions.swift
+++ b/Sources/A2UISwiftCore/Schema/RawComponentExtensions.swift
@@ -49,7 +49,7 @@ extension RawComponent {
 // MARK: - A2UIAccessibility
 
 /// Accessibility attributes for v0.9 components.
-public struct A2UIAccessibility: Sendable {
+public struct A2UIAccessibility: Sendable, Equatable {
     public var label: DynamicString?
     public var description: DynamicString?
 

--- a/Sources/A2UISwiftCore/Schema/ServerToClient.swift
+++ b/Sources/A2UISwiftCore/Schema/ServerToClient.swift
@@ -157,7 +157,7 @@ public struct DeleteSurfacePayload: Codable, Sendable {
 /// The fixed fields `id`, `component`, `weight`, and `accessibility` are extracted;
 /// all remaining keys become `properties`.
 /// Mirrors WebCore `AnyComponentSchema`.
-public struct RawComponent: Sendable {
+public struct RawComponent: Sendable, Equatable {
     public var id: String
     public var component: String
     public var weight: Double?

--- a/Sources/A2UISwiftUI/SurfaceViewModel.swift
+++ b/Sources/A2UISwiftUI/SurfaceViewModel.swift
@@ -399,7 +399,7 @@ public final class SurfaceViewModel {
 
     // MARK: - In-place tree update (avoids full SwiftUI re-render)
 
-    /// Reconciles `existing` against `new` in place. Returns `true` when `existing`s `existing` against `new` in place. Returns `true` when `existing`
+    /// Reconciles `existing` against `new` in place. Returns `true` when `existing`
     /// can be reused (caller keeps the same `componentTree` reference); `false` when
     /// the root identity or type changed and the caller must replace the tree.
     ///
@@ -417,7 +417,7 @@ public final class SurfaceViewModel {
 
     /// O(n) keyed reconcile by `ComponentNode.id`. Reuses matched children (with
     /// type check, Flutter-style), adopts new ones unchanged, drops removed ones.
-    /// `existing.children` is only reassigned when the id sequence changed.
+    /// `existing.children` is only reassigned when node identity or order changed.
     private func reconcileChildren(existing: ComponentNode, newChildren: [ComponentNode]) {
         // `uniquingKeysWith` guards the (currently impossible) case of duplicate
         // sibling ids — keep the first so we don't lose `uiState` on a collision.
@@ -436,7 +436,8 @@ public final class SurfaceViewModel {
                 result.append(newChild)
             }
         }
-        if existing.children.map(\.id) != result.map(\.id) {
+        if existing.children.count != result.count ||
+            !existing.children.elementsEqual(result, by: { $0 === $1 }) {
             existing.children = result
         }
     }

--- a/Sources/A2UISwiftUI/SurfaceViewModel.swift
+++ b/Sources/A2UISwiftUI/SurfaceViewModel.swift
@@ -221,7 +221,7 @@ public final class SurfaceViewModel {
         migrateUIStates(node: newTree, from: oldStateMap)
 
         if let existingTree = componentTree,
-           updateTreeInPlace(existing: existingTree, from: newTree) {
+           reconcileNode(existing: existingTree, new: newTree) {
             return
         }
 
@@ -397,17 +397,48 @@ public final class SurfaceViewModel {
         return ":\((parentIndices.map(String.init) + [String(index)]).joined(separator: ":"))"
     }
 
-    // MARK: - In-place tree update (avoids full SwiftUI re-render for data-only changes)
+    // MARK: - In-place tree update (avoids full SwiftUI re-render)
 
-    private func updateTreeInPlace(existing: ComponentNode, from new: ComponentNode) -> Bool {
-        guard existing.id == new.id, existing.children.count == new.children.count else { return false }
-        existing.instance = new.instance
-        existing.weight = new.weight
-        if let newState = new.uiState, existing.uiState == nil { existing.uiState = newState }
-        for i in existing.children.indices {
-            if !updateTreeInPlace(existing: existing.children[i], from: new.children[i]) { return false }
-        }
+    /// Reconciles `existing` against `new` in place. Returns `true` when `existing`s `existing` against `new` in place. Returns `true` when `existing`
+    /// can be reused (caller keeps the same `componentTree` reference); `false` when
+    /// the root identity or type changed and the caller must replace the tree.
+    ///
+    /// All writes to `@Observable` fields are guarded by equality so that no-op
+    /// updates do not notify SwiftUI.
+    private func reconcileNode(existing: ComponentNode, new: ComponentNode) -> Bool {
+        guard existing.id == new.id, existing.type == new.type else { return false }
+        if existing.instance != new.instance { existing.instance = new.instance }
+        if existing.weight != new.weight { existing.weight = new.weight }
+        if existing.accessibility != new.accessibility { existing.accessibility = new.accessibility }
+        if existing.uiState == nil, let s = new.uiState { existing.uiState = s }
+        reconcileChildren(existing: existing, newChildren: new.children)
         return true
+    }
+
+    /// O(n) keyed reconcile by `ComponentNode.id`. Reuses matched children (with
+    /// type check, Flutter-style), adopts new ones unchanged, drops removed ones.
+    /// `existing.children` is only reassigned when the id sequence changed.
+    private func reconcileChildren(existing: ComponentNode, newChildren: [ComponentNode]) {
+        // `uniquingKeysWith` guards the (currently impossible) case of duplicate
+        // sibling ids — keep the first so we don't lose `uiState` on a collision.
+        var oldByKey = Dictionary(
+            existing.children.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var result: [ComponentNode] = []
+        result.reserveCapacity(newChildren.count)
+        for newChild in newChildren {
+            if let old = oldByKey.removeValue(forKey: newChild.id),
+               old.type == newChild.type {
+                _ = reconcileNode(existing: old, new: newChild)
+                result.append(old)
+            } else {
+                result.append(newChild)
+            }
+        }
+        if existing.children.map(\.id) != result.map(\.id) {
+            existing.children = result
+        }
     }
 
     // MARK: - UI State

--- a/Sources/A2UISwiftUI/SurfaceViewModel.swift
+++ b/Sources/A2UISwiftUI/SurfaceViewModel.swift
@@ -403,13 +403,14 @@ public final class SurfaceViewModel {
     /// can be reused (caller keeps the same `componentTree` reference); `false` when
     /// the root identity or type changed and the caller must replace the tree.
     ///
-    /// All writes to `@Observable` fields are guarded by equality so that no-op
-    /// updates do not notify SwiftUI.
+    /// No-op writes to the `Equatable` `@Observable` fields below do not notify
+    /// SwiftUI: the `@Observable` macro skips notification when the new value
+    /// compares equal (requires a Swift 6.2+ / Xcode 26 toolchain).
     private func reconcileNode(existing: ComponentNode, new: ComponentNode) -> Bool {
         guard existing.id == new.id, existing.type == new.type else { return false }
-        if existing.instance != new.instance { existing.instance = new.instance }
-        if existing.weight != new.weight { existing.weight = new.weight }
-        if existing.accessibility != new.accessibility { existing.accessibility = new.accessibility }
+        existing.instance = new.instance
+        existing.weight = new.weight
+        existing.accessibility = new.accessibility
         if existing.uiState == nil, let s = new.uiState { existing.uiState = s }
         reconcileChildren(existing: existing, newChildren: new.children)
         return true
@@ -429,8 +430,7 @@ public final class SurfaceViewModel {
         result.reserveCapacity(newChildren.count)
         for newChild in newChildren {
             if let old = oldByKey.removeValue(forKey: newChild.id),
-               old.type == newChild.type {
-                _ = reconcileNode(existing: old, new: newChild)
+               reconcileNode(existing: old, new: newChild) {
                 result.append(old)
             } else {
                 result.append(newChild)

--- a/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
+++ b/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
@@ -578,6 +578,40 @@ struct SurfaceViewModelReconcileTests {
         #expect(root.children[1].instance == childBInstanceBefore)
     }
 
+    @Test("same-id child type change replaces that child node")
+    func sameIdChildTypeChangeReplacesChild() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("child")])
+                ]),
+                RawComponent(id: "child", component: "Text", properties: ["text": .string("A")]),
+            ]
+        )))
+        let root = try #require(vm.componentTree)
+        let oldChild = try #require(root.children.first)
+
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("child")])
+                ]),
+                RawComponent(id: "child", component: "Column", properties: [
+                    "children": .array([])
+                ]),
+            ]
+        )))
+
+        let newChild = try #require(root.children.first)
+        #expect(vm.componentTree === root)
+        #expect(newChild !== oldChild)
+        #expect(newChild.type == .Column)
+    }
+
     @Test("root id changing forces full tree replacement")
     func rootReplacementOnIdChange() throws {
         let vm = makeViewModel()

--- a/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
+++ b/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
@@ -17,6 +17,7 @@
 
 import Testing
 import Foundation
+import Observation
 @testable import A2UISwiftCore
 @testable import A2UISwiftUI
 
@@ -405,6 +406,44 @@ struct SurfaceViewModelReconcileTests {
         #expect(root.children.map(\.id) == childrenArray.map(\.id))
     }
 
+    /// `reconcileNode` assigns `instance`/`weight`/`accessibility` unconditionally
+    /// and relies on the `@Observable` macro skipping notification for equal
+    /// `Equatable` values — a toolchain behavior (Swift 6.2+ / Xcode 26). This test
+    /// fails if the package is built with a toolchain that lacks that dedup.
+    @Test("no-op updateComponents does not notify observers of node fields")
+    func noOpDoesNotNotify() throws {
+        let payload = UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("a"), .string("b")])
+                ]),
+                RawComponent(id: "a", component: "Text", properties: ["text": .string("A")]),
+                RawComponent(id: "b", component: "Text", properties: ["text": .string("B")]),
+            ]
+        )
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        try vm.processMessage(.updateComponents(payload))
+        let root = try #require(vm.componentTree)
+        let childA = try #require(root.children.first)
+
+        let flag = ObservationFlag()
+        withObservationTracking {
+            _ = root.instance
+            _ = root.weight
+            _ = root.accessibility
+            _ = root.children
+            _ = childA.instance
+        } onChange: { [flag] in
+            flag.triggered = true
+        }
+
+        // Replay identical components — no tracked field may notify.
+        try vm.processMessage(.updateComponents(payload))
+        #expect(flag.triggered == false)
+    }
+
     @Test("list growing by one item preserves the original children's identity")
     func listGrowsPreservesIdentity() throws {
         let vm = try makeListSetup(["x", "y", "z"])
@@ -633,4 +672,9 @@ struct SurfaceViewModelReconcileTests {
         #expect(newRoot !== oldRoot)
         #expect(newRoot.type == .Column)
     }
+}
+
+/// Sendable wrapper for observation testing.
+private final class ObservationFlag: @unchecked Sendable {
+    var triggered = false
 }

--- a/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
+++ b/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
@@ -333,3 +333,270 @@ struct SurfaceViewModelBatchTests {
         #expect(vm.componentTree != nil)
     }
 }
+
+// MARK: - Reconciliation behavior
+
+@Suite("SurfaceViewModel reconciliation")
+struct SurfaceViewModelReconcileTests {
+
+    /// Column → Text tree where Text is data-bound to /items/<index>/label, used
+    /// for testing template-driven list growth and shrinkage.
+    private func makeListSetup(_ items: [String]) throws -> SurfaceViewModel {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        // Seed the data model before components arrive so the template can resolve.
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            path: "/items",
+            value: .array(items.map { .dictionary(["label": .string($0)]) })
+        )))
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("row"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "row", component: "Text", properties: [
+                    "text": .dictionary(["path": .string("label")])
+                ]),
+            ]
+        )))
+        return vm
+    }
+
+    @Test("no-op updateComponents preserves root identity and every child identity")
+    func noOpPreservesIdentity() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("a"), .string("b")])
+                ]),
+                RawComponent(id: "a", component: "Text", properties: ["text": .string("A")]),
+                RawComponent(id: "b", component: "Text", properties: ["text": .string("B")]),
+            ]
+        )))
+        let root = try #require(vm.componentTree)
+        let childA = try #require(root.children.first)
+        let childB = try #require(root.children.last)
+        let childrenArray = root.children
+
+        // Replay identical components.
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("a"), .string("b")])
+                ]),
+                RawComponent(id: "a", component: "Text", properties: ["text": .string("A")]),
+                RawComponent(id: "b", component: "Text", properties: ["text": .string("B")]),
+            ]
+        )))
+
+        #expect(vm.componentTree === root)
+        #expect(root.children.first === childA)
+        #expect(root.children.last === childB)
+        // `children` itself must not have been reassigned (no-op invariant).
+        #expect(root.children.map(\.id) == childrenArray.map(\.id))
+    }
+
+    @Test("list growing by one item preserves the original children's identity")
+    func listGrowsPreservesIdentity() throws {
+        let vm = try makeListSetup(["x", "y", "z"])
+        let root = try #require(vm.componentTree)
+        #expect(root.children.count == 3)
+        let originals = root.children
+
+        // Append a 4th item — template should expand without rebuilding.
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            path: "/items",
+            value: .array([
+                .dictionary(["label": .string("x")]),
+                .dictionary(["label": .string("y")]),
+                .dictionary(["label": .string("z")]),
+                .dictionary(["label": .string("w")]),
+            ])
+        )))
+        // updateDataModel alone doesn't rebuild structure; replay updateComponents
+        // to trigger the structural pass that previously would have nuked the tree.
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("row"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "row", component: "Text", properties: [
+                    "text": .dictionary(["path": .string("label")])
+                ]),
+            ]
+        )))
+
+        #expect(vm.componentTree === root)
+        #expect(root.children.count == 4)
+        for i in 0..<3 {
+            #expect(root.children[i] === originals[i])
+        }
+    }
+
+    @Test("list shrinking by one item preserves the surviving children's identity")
+    func listShrinksPreservesIdentity() throws {
+        let vm = try makeListSetup(["x", "y", "z", "w"])
+        let root = try #require(vm.componentTree)
+        #expect(root.children.count == 4)
+        let originals = root.children
+
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            path: "/items",
+            value: .array([
+                .dictionary(["label": .string("x")]),
+                .dictionary(["label": .string("y")]),
+                .dictionary(["label": .string("z")]),
+            ])
+        )))
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("row"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "row", component: "Text", properties: [
+                    "text": .dictionary(["path": .string("label")])
+                ]),
+            ]
+        )))
+
+        #expect(vm.componentTree === root)
+        #expect(root.children.count == 3)
+        for i in 0..<3 {
+            #expect(root.children[i] === originals[i])
+        }
+    }
+
+    @Test("uiState survives list growth on a stateful child")
+    func uiStateSurvivesListGrowth() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        // Seed data: list of two items, each becomes a Tabs.
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            path: "/items",
+            value: .array([.dictionary([:]), .dictionary([:])])
+        )))
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("tabs"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "tabs", component: "Tabs", properties: [
+                    "tabs": .array([])
+                ]),
+            ]
+        )))
+        let root = try #require(vm.componentTree)
+        #expect(root.children.count == 2)
+        let firstTabs = root.children[0]
+        let firstUIState = try #require(firstTabs.uiState)
+        let firstUIStateId = ObjectIdentifier(firstUIState as AnyObject)
+
+        // Grow the list.
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            path: "/items",
+            value: .array([.dictionary([:]), .dictionary([:]), .dictionary([:])])
+        )))
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("tabs"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "tabs", component: "Tabs", properties: [
+                    "tabs": .array([])
+                ]),
+            ]
+        )))
+
+        #expect(root.children.count == 3)
+        let firstAfter = try #require(root.children.first)
+        #expect(firstAfter === firstTabs)
+        let firstUIStateAfter = try #require(firstAfter.uiState)
+        #expect(ObjectIdentifier(firstUIStateAfter as AnyObject) == firstUIStateId)
+    }
+
+    @Test("property change on one node leaves siblings' instance untouched")
+    func singleNodeChange() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("a"), .string("b")])
+                ]),
+                RawComponent(id: "a", component: "Text", properties: ["text": .string("A")]),
+                RawComponent(id: "b", component: "Text", properties: ["text": .string("B")]),
+            ]
+        )))
+        let root = try #require(vm.componentTree)
+        let childAInstanceBefore = root.children[0].instance
+        let childBInstanceBefore = root.children[1].instance
+
+        // Change only child A's text.
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([.string("a"), .string("b")])
+                ]),
+                RawComponent(id: "a", component: "Text", properties: ["text": .string("A-new")]),
+                RawComponent(id: "b", component: "Text", properties: ["text": .string("B")]),
+            ]
+        )))
+
+        #expect(vm.componentTree === root)
+        #expect(root.children[0].instance != childAInstanceBefore)
+        #expect(root.children[1].instance == childBInstanceBefore)
+    }
+
+    @Test("root id changing forces full tree replacement")
+    func rootReplacementOnIdChange() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        try vm.processMessage(makeTextComponent(id: "root", text: "Hello"))
+        let oldRoot = try #require(vm.componentTree)
+
+        // Replace root with a different baseComponentId (still has id "root" so it
+        // builds, but switch the component type to force `reconcileNode` to bail).
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .array([])
+                ]),
+            ]
+        )))
+        let newRoot = try #require(vm.componentTree)
+        #expect(newRoot !== oldRoot)
+        #expect(newRoot.type == .Column)
+    }
+}


### PR DESCRIPTION
Based on detailed info in #36 


Reconcile the component tree by id with equality-guarded writes so
@Observable notifications only fire when something actually changed.

- Match children by `ComponentNode.id` (O(n) HashMap reconcile), with a
  Flutter-style type check before reusing a node — replaces the
  position+count guard that triggered a full root replacement whenever
  a list template grew or shrank by one item.
- Guard `instance`, `weight`, and `accessibility` assignments behind
  `!=`, so a no-op `updateComponents` produces zero SwiftUI invalidations.
- Preserve `ComponentNode` identity (and its `uiState`) across
  list growth/shrinkage; only nodes whose props actually changed
  notify SwiftUI.
- Add `Equatable` conformance to `RawComponent`, `A2UIAccessibility`,
  `FunctionCall`, `Dynamic<T>`, and refine `LiteralDecodable: Equatable`
  to unlock the equality checks above. All synthesized; no behavior
  change to encoders/decoders.

Tests: new `SurfaceViewModelReconcileTests` suite covering no-op
identity preservation, list grow/shrink identity, uiState survival on
a Tabs child across list growth, single-node change isolation, and
root replacement on type change.

Agent.md: updated