### PR TITLE
feat(samples): add A2UI v0.9 demo app (sample_0.9)

### DIFF
--- a/Sources/A2UISwiftCore/BasicCatalog/Functions/BasicFunctions.swift
+++ b/Sources/A2UISwiftCore/BasicCatalog/Functions/BasicFunctions.swift
@@ -497,11 +497,12 @@ private func basicOpenUrl(_ name: String, _ args: [String: AnyCodable], _ contex
     guard let url = URL(string: urlString) else {
         throw A2uiExpressionError("Invalid URL '\(urlString)' for '\(name)'", expression: name)
     }
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
     DispatchQueue.main.async { UIApplication.shared.open(url) }
 #elseif canImport(AppKit)
     NSWorkspace.shared.open(url)
 #endif
+    // watchOS has no public URL-opening API for arbitrary URLs; openUrl is a no-op there.
     return nil
 }
 

--- a/Sources/A2UISwiftUI/SurfaceViewModel.swift
+++ b/Sources/A2UISwiftUI/SurfaceViewModel.swift
@@ -169,7 +169,12 @@ public final class SurfaceViewModel {
         // and SwiftUI views that read those slots re-render automatically.
         let path = payload.path ?? "/"
         try surface.dataModel.set(path, value: payload.value)
-        // Data-only update: tree structure unchanged, no rebuild needed.
+        // Re-resolve the component tree: data-driven list templates
+        // (`children: { componentId, path }`) are expanded at build time against
+        // the data model, so when a server `updateDataModel` arrives after
+        // `updateComponents` the templates must be re-expanded. `rebuildComponentTree`
+        // diffs in place, so static-data changes preserve UI state and stay cheap.
+        rebuildComponentTree()
     }
 
     private func handleDeleteSurface() {

--- a/Sources/A2UISwiftUI/Views/A2UISurfaceView.swift
+++ b/Sources/A2UISwiftUI/Views/A2UISurfaceView.swift
@@ -67,28 +67,49 @@ import A2UISwiftCore
 public struct A2UISurfaceView<Catalog: CustomComponentCatalog>: View {
     private let viewModel: SurfaceViewModel
     private let catalog: Catalog
+    private let scrolls: Bool
     private let onAction: (@Sendable (ResolvedAction) -> Void)?
 
+    /// - Parameters:
+    ///   - viewModel: The surface view model to render.
+    ///   - catalog:   Custom-component catalog for non-builtin component types.
+    ///   - scrolls:   When `true` (default) the surface is wrapped in its own
+    ///     `ScrollView` — the right choice for a full-screen surface. Set to
+    ///     `false` to render the bare component tree so the surface can be
+    ///     embedded inside a `List`, gallery card, or a stack of several
+    ///     surfaces without nested-scroll collapse.
+    ///   - onAction:  Receives resolved actions dispatched from components.
     public init(
         viewModel: SurfaceViewModel,
         catalog: Catalog,
+        scrolls: Bool = true,
         onAction: (@Sendable (ResolvedAction) -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.catalog = catalog
+        self.scrolls = scrolls
         self.onAction = onAction
     }
 
     public var body: some View {
         if let rootNode = viewModel.componentTree {
+            surfaceContent(rootNode)
+                .tint(viewModel.a2uiStyle.primaryColor)
+                .environment(\.a2uiStyle, viewModel.a2uiStyle)
+                .environment(\.a2uiActionHandler, onAction)
+                .environment(\.a2uiCatalog, AnyCustomComponentCatalog(catalog))
+        }
+    }
+
+    @ViewBuilder
+    private func surfaceContent(_ rootNode: ComponentNode) -> some View {
+        if scrolls {
             ScrollView {
                 A2UIComponentView(node: rootNode, surface: viewModel.surface)
                     .padding()
             }
-            .tint(viewModel.a2uiStyle.primaryColor)
-            .environment(\.a2uiStyle, viewModel.a2uiStyle)
-            .environment(\.a2uiActionHandler, onAction)
-            .environment(\.a2uiCatalog, AnyCustomComponentCatalog(catalog))
+        } else {
+            A2UIComponentView(node: rootNode, surface: viewModel.surface)
         }
     }
 }
@@ -104,8 +125,9 @@ extension A2UISurfaceView where Catalog == EmptyCustomCatalog {
     /// ```
     public init(
         viewModel: SurfaceViewModel,
+        scrolls: Bool = true,
         onAction: (@Sendable (ResolvedAction) -> Void)? = nil
     ) {
-        self.init(viewModel: viewModel, catalog: EmptyCustomCatalog(), onAction: onAction)
+        self.init(viewModel: viewModel, catalog: EmptyCustomCatalog(), scrolls: scrolls, onAction: onAction)
     }
 }

--- a/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
+++ b/Tests/A2UISwiftUITests/SurfaceViewModelTests.swift
@@ -169,6 +169,42 @@ struct SurfaceViewModelUpdateDataModelTests {
         #expect(vm.surface.dataModel.get("/user/name") == .string("Alice"))
     }
 
+    @Test("list template re-expands when data arrives after components")
+    func templateExpandsAfterData() throws {
+        let vm = makeViewModel()
+        try vm.processMessage(makeCreateSurface())
+        // Components first: a Column whose children are a data-driven template.
+        try vm.processMessage(.updateComponents(UpdateComponentsPayload(
+            surfaceId: "s1",
+            components: [
+                RawComponent(id: "root", component: "Column", properties: [
+                    "children": .dictionary([
+                        "componentId": .string("item"),
+                        "path": .string("/items"),
+                    ])
+                ]),
+                RawComponent(id: "item", component: "Text", properties: [
+                    "text": .dictionary(["path": .string("text")])
+                ]),
+            ]
+        )))
+        // At this point data is empty → template resolves to 0 children.
+        #expect(vm.componentTree?.children.isEmpty == true)
+
+        // Data arrives after components (spec ordering) → template must re-expand.
+        try vm.processMessage(.updateDataModel(UpdateDataModelPayload(
+            surfaceId: "s1",
+            value: .dictionary([
+                "items": .array([
+                    .dictionary(["text": .string("one")]),
+                    .dictionary(["text": .string("two")]),
+                    .dictionary(["text": .string("three")]),
+                ])
+            ])
+        )))
+        #expect(vm.componentTree?.children.count == 3)
+    }
+
     @Test("updateDataModel at root path replaces data")
     func writesToRoot() throws {
         let vm = makeViewModel()

--- a/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.pbxproj
+++ b/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.pbxproj
@@ -1,0 +1,543 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F1143E6F2F51B70000370002 /* A2UISwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = F1143E6F2F51B70000370001 /* A2UISwiftCore */; };
+		F1143E6F2F51B70000370004 /* A2UISwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = F1143E6F2F51B70000370003 /* A2UISwiftUI */; };
+		F11A75462F783999005270A2 /* A2UISwiftCore in Frameworks */ = {isa = PBXBuildFile; productRef = F11A75462F783999005270A1 /* A2UISwiftCore */; };
+		F11A75462F783999005270A4 /* A2UISwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = F11A75462F783999005270A3 /* A2UISwiftUI */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F1143E392F51B6CD0037701E /* A2UIDemoWatchApp Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "A2UIDemoWatchApp Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1FAD1872F4DA60400BE5C9D /* A2UIDemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = A2UIDemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		F1143E3D2F51B6CD0037701E /* A2UIDemoWatchApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = A2UIDemoWatchApp;
+			sourceTree = "<group>";
+		};
+		F1FAD1892F4DA60400BE5C9D /* A2UIDemoApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = A2UIDemoApp;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F1143E362F51B6CD0037701E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1143E6F2F51B70000370002 /* A2UISwiftCore in Frameworks */,
+				F1143E6F2F51B70000370004 /* A2UISwiftUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1FAD1842F4DA60400BE5C9D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F11A75462F783999005270A2 /* A2UISwiftCore in Frameworks */,
+				F11A75462F783999005270A4 /* A2UISwiftUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F1FAD17E2F4DA60400BE5C9D = {
+			isa = PBXGroup;
+			children = (
+				F1FAD1892F4DA60400BE5C9D /* A2UIDemoApp */,
+				F1143E3D2F51B6CD0037701E /* A2UIDemoWatchApp */,
+				F1FAD1882F4DA60400BE5C9D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F1FAD1882F4DA60400BE5C9D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F1FAD1872F4DA60400BE5C9D /* A2UIDemoApp.app */,
+				F1143E392F51B6CD0037701E /* A2UIDemoWatchApp Watch App.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F1143E382F51B6CD0037701E /* A2UIDemoWatchApp Watch App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F1143E632F51B6CE0037701E /* Build configuration list for PBXNativeTarget "A2UIDemoWatchApp Watch App" */;
+			buildPhases = (
+				F1143E352F51B6CD0037701E /* Sources */,
+				F1143E362F51B6CD0037701E /* Frameworks */,
+				F1143E372F51B6CD0037701E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F1143E3D2F51B6CD0037701E /* A2UIDemoWatchApp */,
+			);
+			name = "A2UIDemoWatchApp Watch App";
+			packageProductDependencies = (
+				F1143E6F2F51B70000370001 /* A2UISwiftCore */,
+				F1143E6F2F51B70000370003 /* A2UISwiftUI */,
+			);
+			productName = "A2UIDemoWatchApp Watch App";
+			productReference = F1143E392F51B6CD0037701E /* A2UIDemoWatchApp Watch App.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F1FAD1862F4DA60400BE5C9D /* A2UIDemoApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F1FAD1A82F4DA60500BE5C9D /* Build configuration list for PBXNativeTarget "A2UIDemoApp" */;
+			buildPhases = (
+				F1FAD1832F4DA60400BE5C9D /* Sources */,
+				F1FAD1842F4DA60400BE5C9D /* Frameworks */,
+				F1FAD1852F4DA60400BE5C9D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F1FAD1892F4DA60400BE5C9D /* A2UIDemoApp */,
+			);
+			name = A2UIDemoApp;
+			packageProductDependencies = (
+				F11A75462F783999005270A1 /* A2UISwiftCore */,
+				F11A75462F783999005270A3 /* A2UISwiftUI */,
+			);
+			productName = A2UIDemoApp;
+			productReference = F1FAD1872F4DA60400BE5C9D /* A2UIDemoApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F1FAD17F2F4DA60400BE5C9D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2630;
+				LastUpgradeCheck = 2620;
+				TargetAttributes = {
+					F1143E382F51B6CD0037701E = {
+						CreatedOnToolsVersion = 26.3;
+					};
+					F1FAD1862F4DA60400BE5C9D = {
+						CreatedOnToolsVersion = 26.2;
+					};
+				};
+			};
+			buildConfigurationList = F1FAD1822F4DA60400BE5C9D /* Build configuration list for PBXProject "A2UIDemoApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F1FAD17E2F4DA60400BE5C9D;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = F1FAD1882F4DA60400BE5C9D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F1FAD1862F4DA60400BE5C9D /* A2UIDemoApp */,
+				F1143E382F51B6CD0037701E /* A2UIDemoWatchApp Watch App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F1143E372F51B6CD0037701E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1FAD1852F4DA60400BE5C9D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F1143E352F51B6CD0037701E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1FAD1832F4DA60400BE5C9D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F1143E5D2F51B6CE0037701E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = A2UIDemoWatchApp;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fooman.glass.A2UIDemoWatchApp.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Debug;
+		};
+		F1143E5E2F51B6CE0037701E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = A2UIDemoWatchApp;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fooman.glass.A2UIDemoWatchApp.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Release;
+		};
+		F1FAD1A62F4DA60500BE5C9D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F1FAD1A72F4DA60500BE5C9D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		F1FAD1A92F4DA60500BE5C9D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = A2UIDemoApp/A2UIDemoApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=appletvos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=appletvsimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=appletvos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=appletvsimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fooman.glass.A2UIDemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				TVOS_DEPLOYMENT_TARGET = 26.2;
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Debug;
+		};
+		F1FAD1AA2F4DA60500BE5C9D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = A2UIDemoApp/A2UIDemoApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2JSKY93FHH;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=appletvos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=appletvsimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=appletvos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=appletvsimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fooman.glass.A2UIDemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,7";
+				TVOS_DEPLOYMENT_TARGET = 26.2;
+				XROS_DEPLOYMENT_TARGET = 26.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F1143E632F51B6CE0037701E /* Build configuration list for PBXNativeTarget "A2UIDemoWatchApp Watch App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1143E5D2F51B6CE0037701E /* Debug */,
+				F1143E5E2F51B6CE0037701E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F1FAD1822F4DA60400BE5C9D /* Build configuration list for PBXProject "A2UIDemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1FAD1A62F4DA60500BE5C9D /* Debug */,
+				F1FAD1A72F4DA60500BE5C9D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F1FAD1A82F4DA60500BE5C9D /* Build configuration list for PBXNativeTarget "A2UIDemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1FAD1A92F4DA60500BE5C9D /* Debug */,
+				F1FAD1AA2F4DA60500BE5C9D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		F11A75452F78399900527023 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../..";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F1143E6F2F51B70000370001 /* A2UISwiftCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = A2UISwiftCore;
+		};
+		F1143E6F2F51B70000370003 /* A2UISwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = A2UISwiftUI;
+		};
+		F11A75462F783999005270A1 /* A2UISwiftCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = A2UISwiftCore;
+		};
+		F11A75462F783999005270A3 /* A2UISwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = A2UISwiftUI;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = F1FAD17F2F4DA60400BE5C9D /* Project object */;
+}

--- a/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/samples/sample_0.9/A2UIDemoApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "78e293cf77322b36117ac831839baa4a9c20d261b9c0fdb3cab52a873a9a336f",
+  "pins" : [
+    {
+      "identity" : "swift-foundation-icu",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-foundation-icu.git",
+      "state" : {
+        "branch" : "swift-6.3.1-RELEASE",
+        "revision" : "2e2854eee567589ed44c5f3c85c7343e6d91978d"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/samples/sample_0.9/A2UIDemoApp.xcodeproj/xcshareddata/xcschemes/A2UIDemoApp.xcscheme
+++ b/samples/sample_0.9/A2UIDemoApp.xcodeproj/xcshareddata/xcschemes/A2UIDemoApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F1FAD1862F4DA60400BE5C9D"
+               BuildableName = "A2UIDemoApp.app"
+               BlueprintName = "A2UIDemoApp"
+               ReferencedContainer = "container:A2UIDemoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F1FAD1862F4DA60400BE5C9D"
+            BuildableName = "A2UIDemoApp.app"
+            BlueprintName = "A2UIDemoApp"
+            ReferencedContainer = "container:A2UIDemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F1FAD1862F4DA60400BE5C9D"
+            BuildableName = "A2UIDemoApp.app"
+            BlueprintName = "A2UIDemoApp"
+            ReferencedContainer = "container:A2UIDemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/samples/sample_0.9/A2UIDemoApp/A2UIDemoApp.entitlements
+++ b/samples/sample_0.9/A2UIDemoApp/A2UIDemoApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/samples/sample_0.9/A2UIDemoApp/A2UIDemoApp.swift
+++ b/samples/sample_0.9/A2UIDemoApp/A2UIDemoApp.swift
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+@main
+struct A2UIDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,85 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/Contents.json
+++ b/samples/sample_0.9/A2UIDemoApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Components/RizzchartChartView.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Components/RizzchartChartView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import Charts
+import A2UISwiftCore
+
+/// Swift Charts implementation of the Rizzcharts doughnut/pie chart with drill-down.
+struct RizzchartChartView: View {
+    let node: ComponentNode
+    let surface: SurfaceModel
+
+    @State private var selectedCategory: String?
+
+    private var dataContext: DataContext {
+        DataContext(surface: surface, path: node.dataContextPath)
+    }
+
+    /// Resolves a property that may be a literal value or a `{ "path": "..." }` binding.
+    private func resolve(_ prop: AnyCodable?) -> AnyCodable? {
+        guard let prop else { return nil }
+        if let path = prop.dictionaryValue?["path"]?.stringValue {
+            return surface.dataModel.get(dataContext.resolvePath(path))
+        }
+        return prop
+    }
+
+    private var properties: [String: AnyCodable] { node.instance.properties }
+
+    private var chartType: String {
+        properties["type"]?.stringValue ?? "doughnut"
+    }
+
+    private var title: String {
+        resolve(properties["title"])?.stringValue ?? ""
+    }
+
+    private var chartItems: [ChartItem] {
+        guard let data = resolve(properties["chartData"]), case .array(let items) = data else {
+            return []
+        }
+        return items.compactMap { item -> ChartItem? in
+            guard case .dictionary(let dict) = item,
+                  let label = dict["label"]?.stringValue,
+                  let value = dict["value"]?.numberValue else { return nil }
+            var drillDown: [ChartItem] = []
+            if case .array(let subs) = dict["drillDown"] {
+                drillDown = subs.compactMap { sub -> ChartItem? in
+                    guard case .dictionary(let d) = sub,
+                          let l = d["label"]?.stringValue,
+                          let v = d["value"]?.numberValue else { return nil }
+                    return ChartItem(label: l, value: v, drillDown: [])
+                }
+            }
+            return ChartItem(label: label, value: value, drillDown: drillDown)
+        }
+    }
+
+    private var displayItems: [ChartItem] {
+        if let cat = selectedCategory,
+           let parent = chartItems.first(where: { $0.label == cat }),
+           !parent.drillDown.isEmpty {
+            return parent.drillDown
+        }
+        return chartItems
+    }
+
+    private var displayTitle: String {
+        if let cat = selectedCategory { return cat }
+        return title
+    }
+
+    private var total: Double {
+        displayItems.reduce(0) { $0 + $1.value }
+    }
+
+    private static let palette: [Color] = [
+        .blue, .green, .orange, .purple, .red,
+        .cyan, .pink, .yellow, .mint, .indigo
+    ]
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                if selectedCategory != nil {
+                    Button {
+                        withAnimation { selectedCategory = nil }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "chevron.left")
+                            Text("Back")
+                        }
+                        .font(.subheadline)
+                    }
+                }
+                Spacer()
+                Text(displayTitle)
+                    .font(.headline)
+                Spacer()
+                if selectedCategory != nil {
+                    Color.clear.frame(width: 50, height: 1)
+                }
+            }
+
+            Chart(displayItems) { item in
+                SectorMark(
+                    angle: .value("Value", item.value),
+                    innerRadius: .ratio(chartType == "doughnut" ? 0.5 : 0),
+                    angularInset: 1.5
+                )
+                .foregroundStyle(by: .value("Category", item.label))
+                .annotation(position: .overlay) {
+                    let pct = total > 0 ? item.value / total * 100 : 0
+                    if pct >= 5 {
+                        Text("\(Int(pct.rounded()))%")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                    }
+                }
+            }
+            .chartForegroundStyleScale(domain: displayItems.map(\.label), range: colorRange)
+            .frame(height: 260)
+
+            legendView
+        }
+        .padding()
+    }
+
+    private var colorRange: [Color] {
+        displayItems.indices.map { Self.palette[$0 % Self.palette.count] }
+    }
+
+    @ViewBuilder
+    private var legendView: some View {
+        let columns = [GridItem(.adaptive(minimum: 120), spacing: 8)]
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(displayItems) { item in
+                let idx = displayItems.firstIndex(where: { $0.id == item.id }) ?? 0
+                let color = Self.palette[idx % Self.palette.count]
+                let hasDrill = !item.drillDown.isEmpty && selectedCategory == nil
+
+                Button {
+                    if hasDrill {
+                        withAnimation { selectedCategory = item.label }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(color)
+                            .frame(width: 10, height: 10)
+                        Text(item.label)
+                            .font(.caption)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(String(format: "%.0f", item.value))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        if hasDrill {
+                            Image(systemName: "chevron.right")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Data Model
+
+struct ChartItem: Identifiable {
+    let label: String
+    let value: Double
+    let drillDown: [ChartItem]
+    var id: String { label }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Components/RizzchartMapView.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Components/RizzchartMapView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import MapKit
+import A2UISwiftCore
+
+/// MapKit implementation of the Rizzcharts GoogleMap component.
+struct RizzchartMapView: View {
+    let node: ComponentNode
+    let surface: SurfaceModel
+
+    private var dataContext: DataContext {
+        DataContext(surface: surface, path: node.dataContextPath)
+    }
+
+    private func resolve(_ prop: AnyCodable?) -> AnyCodable? {
+        guard let prop else { return nil }
+        if let path = prop.dictionaryValue?["path"]?.stringValue {
+            return surface.dataModel.get(dataContext.resolvePath(path))
+        }
+        return prop
+    }
+
+    private var properties: [String: AnyCodable] { node.instance.properties }
+
+    private var centerCoord: CLLocationCoordinate2D {
+        guard let data = resolve(properties["center"]),
+              case .dictionary(let dict) = data,
+              let lat = dict["lat"]?.numberValue,
+              let lng = dict["lng"]?.numberValue else {
+            return CLLocationCoordinate2D(latitude: 34.0522, longitude: -118.2437)
+        }
+        return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    }
+
+    private var zoomLevel: Double {
+        resolve(properties["zoom"])?.numberValue ?? 11
+    }
+
+    /// Convert Google Maps zoom level (0-21) to approximate MapKit camera distance.
+    private var cameraDistance: Double {
+        let z = max(0, min(21, zoomLevel))
+        return 40_075_000 / pow(2, z) * 1.5
+    }
+
+    private var pins: [MapPin] {
+        guard let data = resolve(properties["pins"]), case .array(let items) = data else {
+            return []
+        }
+        return items.enumerated().compactMap { (idx, item) -> MapPin? in
+            guard case .dictionary(let dict) = item,
+                  let lat = dict["lat"]?.numberValue,
+                  let lng = dict["lng"]?.numberValue else { return nil }
+            return MapPin(
+                id: idx,
+                coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lng),
+                name: dict["name"]?.stringValue ?? "Pin \(idx + 1)",
+                description: dict["description"]?.stringValue
+            )
+        }
+    }
+
+    var body: some View {
+        Map(initialPosition: .camera(MapCamera(
+            centerCoordinate: centerCoord,
+            distance: cameraDistance
+        ))) {
+            ForEach(pins) { pin in
+                Marker(pin.name, coordinate: pin.coordinate)
+            }
+        }
+        .frame(height: 400)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+
+        if !pins.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(pins) { pin in
+                    HStack(spacing: 8) {
+                        Image(systemName: "mappin.circle.fill")
+                            .foregroundStyle(.red)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(pin.name)
+                                .font(.subheadline.weight(.medium))
+                            if let desc = pin.description {
+                                Text(desc)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+            .padding(.top, 8)
+        }
+    }
+}
+
+// MARK: - Data Model
+
+struct MapPin: Identifiable {
+    let id: Int
+    let coordinate: CLLocationCoordinate2D
+    let name: String
+    let description: String?
+}

--- a/samples/sample_0.9/A2UIDemoApp/ContentView.swift
+++ b/samples/sample_0.9/A2UIDemoApp/ContentView.swift
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    NavigationLink {
+                        CatalogPage()
+                    } label: {
+                        Label("Component Gallery", systemImage: "square.grid.2x2")
+                    }
+
+                    NavigationLink {
+                        ActionDemoPage(
+                            filename: "action_context",
+                            title: "Action Context",
+                            subtitle: "Path-bound data in action payload",
+                            info: "When a Button is tapped, the renderer reads values from the data model using the paths defined in action.context, then packages them into a resolved action payload to send back to the agent. Edit the fields and tap Send to see the resolved result."
+                        )
+                    } label: {
+                        Label("Action Context", systemImage: "arrow.up.message")
+                    }
+
+                    NavigationLink {
+                        ActionDemoPage(
+                            filename: "format_functions",
+                            title: "Format Functions",
+                            subtitle: "formatDate in action context",
+                            info: "Action context values can use function calls like formatDate to transform data before sending. Compare rawDate (the original ISO string from the data model) with formatted (processed by formatDate) in the resolved action."
+                        )
+                    } label: {
+                        Label("Format Functions", systemImage: "calendar.badge.clock")
+                    }
+                    NavigationLink {
+                        StyleOverridePage()
+                    } label: {
+                        Label("Style Override", systemImage: "paintbrush")
+                    }
+
+                    NavigationLink {
+                        CustomComponentPage()
+                    } label: {
+                        Label("Custom Component", systemImage: "star.square.on.square")
+                    }
+
+                    NavigationLink {
+                        IncrementalUpdatePage()
+                    } label: {
+                        Label("Incremental Update", systemImage: "arrow.triangle.2.circlepath")
+                    }
+
+                    NavigationLink {
+                        RizzchartsPage()
+                    } label: {
+                        Label("Rizzcharts", systemImage: "chart.pie")
+                    }
+                } header: {
+                    Text("Native Static Demos")
+                } footer: {
+                    Text("Run entirely on-device with static JSON. No agent connection required.")
+                }
+
+                Section {
+                    NavigationLink {
+                        LiveAgentPage(
+                            agentURL: URL(string: "http://localhost:10005")!,
+                            initialQuery: "START_GALLERY"
+                        )
+                    } label: {
+                        Label("Component Gallery", systemImage: "antenna.radiowaves.left.and.right")
+                    }
+                } header: {
+                    Text("Live Agent — Gallery")
+                } footer: {
+                    Text("Hardcoded gallery with per-surface demo cards.")
+                }
+
+                Section {
+                    NavigationLink {
+                        AgentChatPage(
+                            title: "Contact Lookup",
+                            agentURL: URL(string: "http://localhost:10003")!,
+                            initialQuery: "Find Alex Jordan in Marketing"
+                        )
+                    } label: {
+                        Label("Contact Lookup", systemImage: "person.crop.rectangle")
+                    }
+
+                    NavigationLink {
+                        AgentCardPage(
+                            title: "Restaurant Finder",
+                            agentURL: URL(string: "http://localhost:10002")!,
+                            initialQuery: "Find me Chinese restaurants in New York"
+                        )
+                    } label: {
+                        Label("Restaurant Finder", systemImage: "fork.knife")
+                    }
+
+                    NavigationLink {
+                        AgentChatPage(
+                            title: "Rizzcharts",
+                            agentURL: URL(string: "http://localhost:10004")!,
+                            initialQuery: "Show my sales breakdown by product category for Q3"
+                        )
+                    } label: {
+                        Label("Rizzcharts", systemImage: "chart.pie")
+                    }
+                } header: {
+                    Text("Live Agent")
+                } footer: {
+                    Text("Connect to live agents running on localhost.")
+                }
+
+                Section("Samples") {
+                    ForEach(SampleDemo.allCases.filter {
+                        $0 != .actionContext && $0 != .formatFunctions && $0 != .incrementalUpdate
+                    }) { demo in
+                        NavigationLink {
+                            SampleDetailPage(demo: demo)
+                        } label: {
+                            Label(demo.rawValue, systemImage: demo.icon)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("A2UI Demo")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/samples/sample_0.9/A2UIDemoApp/Networking/A2AClient.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Networking/A2AClient.swift
@@ -1,0 +1,499 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import A2UISwiftCore
+
+/// HTTP client that speaks the A2A JSON-RPC protocol to an A2UI-capable agent,
+/// decoding v0.9 `A2uiMessage` payloads.
+///
+/// ```swift
+/// let client = try await A2AClient.fromBaseURL(URL(string: "http://localhost:10003")!)
+/// let result = try await client.sendText("Find me restaurants")
+/// ```
+public final class A2AClient: Sendable {
+
+    public let endpointURL: URL
+    public let agentCard: AgentCardInfo?
+
+    private let session: URLSession
+
+    private static let extensionHeader = "https://a2ui.org/a2a-extension/a2ui/v0.9"
+    private static let a2uiMimeType = "application/json+a2ui"
+    private static let standardCatalogId = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+
+    public init(endpointURL: URL, timeoutInterval: TimeInterval = 120) {
+        self.endpointURL = endpointURL
+        self.agentCard = nil
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = timeoutInterval
+        self.session = URLSession(configuration: config)
+    }
+
+    private init(endpointURL: URL, agentCard: AgentCardInfo, timeoutInterval: TimeInterval) {
+        self.endpointURL = endpointURL
+        self.agentCard = agentCard
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = timeoutInterval
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Factory
+
+    public static func fromAgentCardURL(
+        _ cardURL: URL,
+        timeoutInterval: TimeInterval = 120
+    ) async throws -> A2AClient {
+        var request = URLRequest(url: cardURL)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(extensionHeader, forHTTPHeaderField: "X-A2A-Extensions")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw A2AError.agentCardFetchFailed(url: cardURL)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let urlString = json["url"] as? String,
+              let endpointURL = URL(string: urlString) else {
+            throw A2AError.agentCardInvalid
+        }
+
+        let card = AgentCardInfo(
+            name: json["name"] as? String ?? "Unknown",
+            url: urlString,
+            streaming: (json["capabilities"] as? [String: Any])?["streaming"] as? Bool ?? false,
+            iconUrl: json["iconUrl"] as? String,
+            supportedCatalogIds: Self.extractCatalogIds(from: json)
+        )
+
+        return A2AClient(endpointURL: endpointURL, agentCard: card, timeoutInterval: timeoutInterval)
+    }
+
+    public static func fromBaseURL(
+        _ baseURL: URL,
+        timeoutInterval: TimeInterval = 120
+    ) async throws -> A2AClient {
+        let cardURL = baseURL.appendingPathComponent(".well-known/agent-card.json")
+        return try await fromAgentCardURL(cardURL, timeoutInterval: timeoutInterval)
+    }
+
+    // MARK: - Public API
+
+    private var supportedCatalogIds: [String] {
+        if let card = agentCard, !card.supportedCatalogIds.isEmpty {
+            var custom: [String] = []
+            var standard: [String] = []
+            for id in card.supportedCatalogIds {
+                if id == Self.standardCatalogId { standard.append(id) } else { custom.append(id) }
+            }
+            return custom + standard
+        }
+        return [Self.standardCatalogId]
+    }
+
+    private static func extractCatalogIds(from json: [String: Any]) -> [String] {
+        guard let capabilities = json["capabilities"] as? [String: Any],
+              let extensions = capabilities["extensions"] as? [[String: Any]] else {
+            return []
+        }
+        var ids: [String] = []
+        for ext in extensions {
+            if let params = ext["params"] as? [String: Any],
+               let catalogIds = params["supportedCatalogIds"] as? [String] {
+                ids.append(contentsOf: catalogIds)
+            }
+        }
+        return ids
+    }
+
+    public func sendText(_ text: String, contextId: String? = nil) async throws -> SendResult {
+        let parts: [[String: Any]] = [["kind": "text", "text": text]]
+        return try await sendMessage(parts: parts, contextId: contextId)
+    }
+
+    public func sendAction(
+        _ action: ResolvedAction,
+        surfaceId: String,
+        contextId: String? = nil
+    ) async throws -> SendResult {
+        return try await sendMessage(parts: makeActionParts(action, surfaceId: surfaceId), contextId: contextId)
+    }
+
+    // MARK: - Shared Helpers
+
+    private func makeActionParts(_ action: ResolvedAction, surfaceId: String) -> [[String: Any]] {
+        let userAction: [String: Any] = [
+            "userAction": [
+                "name": action.name,
+                "actionName": action.name,
+                "surfaceId": surfaceId,
+                "sourceComponentId": action.sourceComponentId,
+                "timestamp": ISO8601DateFormatter().string(from: Date()),
+                "context": action.context.mapValues { $0.toJSONValue() }
+            ] as [String: Any]
+        ]
+        return [
+            [
+                "kind": "data",
+                "data": userAction,
+                "metadata": ["mimeType": Self.a2uiMimeType]
+            ]
+        ]
+    }
+
+    private func buildJSONRPCBody(
+        method: String,
+        parts: [[String: Any]],
+        contextId: String?
+    ) throws -> Data {
+        var messageDict: [String: Any] = [
+            "messageId": UUID().uuidString,
+            "role": "user",
+            "parts": parts,
+            "kind": "message",
+            "metadata": [
+                "a2uiClientCapabilities": [
+                    "supportedCatalogIds": supportedCatalogIds
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+        if let contextId { messageDict["contextId"] = contextId }
+
+        let body: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": UUID().uuidString,
+            "params": ["message": messageDict] as [String: Any]
+        ]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    // MARK: - Streaming API (message/stream via SSE)
+
+    public func sendTextStream(_ text: String, contextId: String? = nil) -> AsyncThrowingStream<StreamEvent, Error> {
+        let parts: [[String: Any]] = [["kind": "text", "text": text]]
+        return sendMessageStream(parts: parts, contextId: contextId)
+    }
+
+    public func sendActionStream(
+        _ action: ResolvedAction,
+        surfaceId: String,
+        contextId: String? = nil
+    ) -> AsyncThrowingStream<StreamEvent, Error> {
+        return sendMessageStream(parts: makeActionParts(action, surfaceId: surfaceId), contextId: contextId)
+    }
+
+    private func sendMessageStream(
+        parts: [[String: Any]],
+        contextId: String?
+    ) -> AsyncThrowingStream<StreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    let jsonData = try self.buildJSONRPCBody(method: "message/stream", parts: parts, contextId: contextId)
+
+                    var request = URLRequest(url: self.endpointURL)
+                    request.httpMethod = "POST"
+                    request.httpBody = jsonData
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                    request.setValue(Self.extensionHeader, forHTTPHeaderField: "X-A2A-Extensions")
+                    request.timeoutInterval = 120
+
+                    let (bytes, response) = try await self.session.bytes(for: request)
+
+                    guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                        let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                        throw A2AError.httpError(statusCode: code, body: "SSE stream failed")
+                    }
+
+                    try await self.parseSSEStream(bytes: bytes, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func parseSSEStream<S: AsyncSequence>(
+        bytes: S,
+        continuation: AsyncThrowingStream<StreamEvent, Error>.Continuation
+    ) async throws where S.Element == UInt8 {
+        var pendingDataLines: [String] = []
+
+        for try await line in bytes.lines {
+            if line.hasPrefix("data:") {
+                let payload = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                if !payload.isEmpty {
+                    if payload.hasPrefix("{"), let event = parseSSEEvent(payload) {
+                        flushPending(&pendingDataLines, to: continuation)
+                        continuation.yield(event)
+                    } else {
+                        pendingDataLines.append(payload)
+                    }
+                }
+            } else if line.isEmpty {
+                flushPending(&pendingDataLines, to: continuation)
+            }
+        }
+        flushPending(&pendingDataLines, to: continuation)
+    }
+
+    private func flushPending(
+        _ lines: inout [String],
+        to continuation: AsyncThrowingStream<StreamEvent, Error>.Continuation
+    ) {
+        guard !lines.isEmpty else { return }
+        let dataContent = lines.joined(separator: "\n")
+        lines.removeAll()
+        if let event = parseSSEEvent(dataContent) {
+            continuation.yield(event)
+        }
+    }
+
+    private func parseSSEEvent(_ dataContent: String) -> StreamEvent? {
+        guard let data = dataContent.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+
+        let event = (json["result"] as? [String: Any]) ?? json
+
+        let taskId = event["taskId"] as? String ?? event["id"] as? String
+        let contextId = event["contextId"] as? String
+        let isFinal = event["final"] as? Bool ?? false
+
+        let taskState: A2ATaskState
+        var statusText: String?
+
+        if let status = event["status"] as? [String: Any],
+           let stateStr = status["state"] as? String {
+            taskState = A2ATaskState(rawValue: stateStr) ?? .unknown
+
+            if let message = status["message"] as? [String: Any],
+               let parts = message["parts"] as? [[String: Any]] {
+                for part in parts {
+                    if let kind = part["kind"] as? String, kind == "text",
+                       let text = part["text"] as? String {
+                        statusText = text
+                    }
+                }
+            }
+        } else {
+            taskState = .unknown
+        }
+
+        let allParts = extractParts(from: event)
+        if let messages = try? decodeA2UIMessages(from: allParts), !messages.isEmpty {
+            return .result(SendResult(
+                messages: messages,
+                taskState: taskState,
+                taskId: taskId,
+                contextId: contextId
+            ))
+        }
+
+        if taskState != .unknown {
+            return .status(state: taskState, text: statusText, taskId: taskId, contextId: contextId, isFinal: isFinal)
+        }
+
+        return nil
+    }
+
+    // MARK: - JSON-RPC Transport (message/send, non-streaming)
+
+    private func sendMessage(parts: [[String: Any]], contextId: String?) async throws -> SendResult {
+        let jsonData = try buildJSONRPCBody(method: "message/send", parts: parts, contextId: contextId)
+
+        var request = URLRequest(url: endpointURL)
+        request.httpMethod = "POST"
+        request.httpBody = jsonData
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(Self.extensionHeader, forHTTPHeaderField: "X-A2A-Extensions")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw A2AError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw A2AError.httpError(statusCode: httpResponse.statusCode, body: body)
+        }
+
+        return try parseResponse(from: data)
+    }
+
+    // MARK: - Response Parsing
+
+    private func parseResponse(from data: Data) throws -> SendResult {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw A2AError.invalidResponse
+        }
+
+        if let error = json["error"] as? [String: Any] {
+            let message = error["message"] as? String ?? "Unknown agent error"
+            throw A2AError.agentError(message: message)
+        }
+
+        guard let result = json["result"] as? [String: Any] else {
+            throw A2AError.invalidResponse
+        }
+
+        let taskId = result["id"] as? String
+        let contextId = result["contextId"] as? String
+        let taskState: A2ATaskState
+        if let status = result["status"] as? [String: Any],
+           let stateStr = status["state"] as? String {
+            taskState = A2ATaskState(rawValue: stateStr) ?? .unknown
+        } else {
+            taskState = .unknown
+        }
+
+        let parts = extractParts(from: result)
+        let messages = try decodeA2UIMessages(from: parts)
+
+        return SendResult(
+            messages: messages,
+            taskState: taskState,
+            taskId: taskId,
+            contextId: contextId
+        )
+    }
+
+    /// Decode v0.9 `A2uiMessage` objects from response parts.
+    private func decodeA2UIMessages(from parts: [[String: Any]]) throws -> [A2uiMessage] {
+        let decoder = JSONDecoder()
+        var messages: [A2uiMessage] = []
+
+        for part in parts {
+            guard let kind = part["kind"] as? String, kind == "data",
+                  let metadata = part["metadata"] as? [String: Any],
+                  let mimeType = metadata["mimeType"] as? String,
+                  mimeType == Self.a2uiMimeType,
+                  let payload = part["data"] else {
+                continue
+            }
+
+            let payloadData = try JSONSerialization.data(withJSONObject: payload)
+
+            if let arr = payload as? [[String: Any]] {
+                for item in arr {
+                    let itemData = try JSONSerialization.data(withJSONObject: item)
+                    messages.append(try decoder.decode(A2uiMessage.self, from: itemData))
+                }
+            } else {
+                messages.append(try decoder.decode(A2uiMessage.self, from: payloadData))
+            }
+        }
+
+        return messages
+    }
+
+    private func extractParts(from result: [String: Any]) -> [[String: Any]] {
+        if let status = result["status"] as? [String: Any],
+           let message = status["message"] as? [String: Any],
+           let parts = message["parts"] as? [[String: Any]] {
+            return parts
+        }
+        if let artifact = result["artifact"] as? [String: Any],
+           let parts = artifact["parts"] as? [[String: Any]] {
+            return parts
+        }
+        if let message = result["message"] as? [String: Any],
+           let parts = message["parts"] as? [[String: Any]] {
+            return parts
+        }
+        if let parts = result["parts"] as? [[String: Any]] {
+            return parts
+        }
+        return []
+    }
+}
+
+// MARK: - Supporting Types
+
+public struct SendResult: Sendable {
+    public let messages: [A2uiMessage]
+    public let taskState: A2ATaskState
+    public let taskId: String?
+    public let contextId: String?
+}
+
+public enum A2ATaskState: String, Sendable {
+    case submitted
+    case working
+    case inputRequired = "input-required"
+    case completed
+    case canceled
+    case failed
+    case rejected
+    case authRequired = "auth-required"
+    case unknown
+}
+
+public enum StreamEvent: Sendable {
+    case status(state: A2ATaskState, text: String?, taskId: String?, contextId: String?, isFinal: Bool)
+    case result(SendResult)
+}
+
+public struct AgentCardInfo: Sendable {
+    public let name: String
+    public let url: String
+    public let streaming: Bool
+    public let iconUrl: String?
+    public let supportedCatalogIds: [String]
+}
+
+// MARK: - Errors
+
+public enum A2AError: LocalizedError {
+    case invalidResponse
+    case httpError(statusCode: Int, body: String)
+    case agentError(message: String)
+    case agentCardFetchFailed(url: URL)
+    case agentCardInvalid
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from A2A agent"
+        case .httpError(let code, let body):
+            return "HTTP \(code): \(body.prefix(200))"
+        case .agentError(let message):
+            return "Agent error: \(message)"
+        case .agentCardFetchFailed(let url):
+            return "Failed to fetch agent card from \(url)"
+        case .agentCardInvalid:
+            return "Agent card is missing required 'url' field"
+        }
+    }
+}
+
+// MARK: - AnyCodable JSON helpers
+
+extension AnyCodable {
+    func toJSONValue() -> Any {
+        switch self {
+        case .string(let s): return s
+        case .number(let n): return n
+        case .bool(let b): return b
+        case .null: return NSNull()
+        case .array(let arr): return arr.map { $0.toJSONValue() }
+        case .dictionary(let dict): return dict.mapValues { $0.toJSONValue() }
+        }
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/ActionDemoPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/ActionDemoPage.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+struct ActionDemoPage: View {
+    let filename: String
+    let title: String
+    let subtitle: String
+    let info: String
+
+    @State private var viewModel: SurfaceViewModel?
+    @State private var errorText: String?
+    @State private var lastAction: ResolvedAction?
+    @State private var showingInspector = false
+
+    var body: some View {
+        List {
+            if let errorText {
+                Section { Text(errorText).foregroundStyle(.red) }
+            } else if let viewModel {
+                Section("Form") {
+                    A2UISurfaceView(viewModel: viewModel, scrolls: false) { action in
+                        lastAction = action
+                    }
+                }
+
+                if let action = lastAction {
+                    Section("Resolved Action") {
+                        LabeledContent("event", value: action.name)
+                        ForEach(action.context.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                            LabeledContent(key, value: displayValue(value))
+                        }
+                    }
+                }
+            } else {
+                ProgressView().task { loadJSON() }
+            }
+        }
+        .navigationTitle(title)
+#if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle(subtitle)
+#endif
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingInspector.toggle()
+                } label: {
+                    Label("About", systemImage: "info.circle")
+                }
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showingInspector) {
+            ScrollView {
+                Text(info)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 400)
+        }
+#endif
+    }
+
+    private func displayValue(_ value: AnyCodable) -> String {
+        switch value {
+        case .string(let s): return s
+        case .number(let n): return "\(n)"
+        case .bool(let b): return "\(b)"
+        case .null: return "null"
+        default: return "\(value)"
+        }
+    }
+
+    private func loadJSON() {
+        do {
+            let messages = try DemoMessages.load(filename)
+            viewModel = makeSurfaceViewModel(from: messages)
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/AgentCardPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/AgentCardPage.swift
@@ -1,0 +1,410 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+/// Card-style agent page matching the official Lit shell pattern:
+///
+/// 1. Initial: hero area + search form (pre-filled placeholder, no auto-send)
+/// 2. User submits → form hides, loading animation with rotating text
+/// 3. Result → A2UI surfaces replace the loading area
+/// 4. User action → loading → new surfaces replace old ones
+struct AgentCardPage: View {
+    let title: String
+    let agentURL: URL
+    let initialQuery: String
+    var loadingTexts: [String] = [
+        "Finding the best spots for you...",
+        "Checking reviews...",
+        "Looking for open tables...",
+        "Almost there..."
+    ]
+
+    @State private var store = SurfaceStore()
+    @State private var client: A2AClient?
+    @State private var status: ConnectionStatus = .idle
+    @State private var actionLog: [ActionLogEntry] = []
+    @State private var showLog = false
+    @State private var queryText = ""
+    @State private var isSending = false
+    @State private var contextId: String?
+    @State private var loadingTextIndex = 0
+    @State private var loadingTimer: Timer?
+    @State private var hasResults = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            switch status {
+            case .idle, .connecting:
+                ProgressView("Connecting to Agent...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .connected:
+                connectedContent
+            case .error(let message):
+                ContentUnavailableView(
+                    "Connection Failed",
+                    systemImage: "wifi.exclamationmark",
+                    description: Text(message)
+                )
+            }
+        }
+        .navigationTitle(title)
+#if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle(status.subtitle(url: agentURL))
+#endif
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showLog.toggle()
+                } label: {
+                    Label("Log", systemImage: "list.bullet.rectangle")
+                }
+#if !os(tvOS)
+                .badge(actionLog.count)
+#endif
+                .id(actionLog.count)
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showLog) {
+            actionLogView
+                .inspectorColumnWidth(min: 260, ideal: 320, max: 450)
+        }
+#endif
+        .task { await connect() }
+    }
+
+    // MARK: - Connected Content
+
+    private var connectedContent: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if !hasResults && !isSending {
+                    heroSection
+                } else if isSending {
+                    loadingSection
+                } else {
+                    resultSection
+                }
+            }
+            .frame(maxWidth: 640)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Hero / Search Form
+
+    private var heroSection: some View {
+        VStack(spacing: 24) {
+            Spacer().frame(height: 40)
+
+            Image(systemName: "fork.knife.circle.fill")
+                .font(.system(size: 72))
+                .foregroundStyle(.tint)
+
+            Text(title)
+                .font(.largeTitle.bold())
+
+            HStack(spacing: 8) {
+                TextField("What are you looking for?", text: $queryText)
+#if !os(tvOS)
+                    .textFieldStyle(.roundedBorder)
+#endif
+                    .onSubmit { submitQuery() }
+
+                Button {
+                    submitQuery()
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .disabled(queryText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .onAppear {
+            if queryText.isEmpty {
+                queryText = initialQuery
+            }
+        }
+    }
+
+    // MARK: - Loading Animation
+
+    private var loadingSection: some View {
+        VStack(spacing: 16) {
+            Spacer().frame(height: 120)
+
+            ProgressView()
+                .scaleEffect(1.5)
+
+            Text(loadingTexts[loadingTextIndex])
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .animation(.easeInOut, value: loadingTextIndex)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Result Surfaces
+
+    private var resultSection: some View {
+        LazyVStack(spacing: 0) {
+            ForEach(store.orderedSurfaceIds, id: \.self) { surfaceId in
+                if let vm = store.viewModels[surfaceId] {
+                    A2UISurfaceView(viewModel: vm, catalog: RizzCustomCatalog(), scrolls: false) { action in
+                        logAction(action, surfaceId: surfaceId)
+                        Task { await sendAction(action, surfaceId: surfaceId) }
+                    }
+                    .padding()
+                }
+            }
+        }
+    }
+
+    // MARK: - Action Log
+
+    private var actionLogView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Action Log", systemImage: "list.bullet.rectangle")
+                    .font(.subheadline.bold())
+                Spacer()
+                if !actionLog.isEmpty {
+                    Button("Clear") { actionLog.removeAll() }
+                        .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+#if !os(tvOS)
+            .background(.bar)
+#endif
+
+            if actionLog.isEmpty {
+                Text("Interact with components to see actions here.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(actionLog) { entry in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Image(systemName: entry.direction == .outgoing
+                                  ? "arrow.up.circle.fill"
+                                  : "arrow.down.circle.fill")
+                            .foregroundStyle(entry.direction == .outgoing ? .blue : .green)
+                            Text(entry.summary).font(.subheadline).bold()
+                            Spacer()
+                            Text(entry.timestamp, style: .time)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        if !entry.detail.isEmpty {
+                            Text(entry.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(4)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Networking
+
+    private var supportsStreaming: Bool {
+        client?.agentCard?.streaming == true
+    }
+
+    private func connect() async {
+        status = .connecting
+        do {
+            let a2aClient = try await A2AClient.fromBaseURL(agentURL)
+            client = a2aClient
+            logEntry(.incoming, summary: "Connected",
+                     detail: "Discovered \(a2aClient.agentCard?.name ?? "Agent") at \(a2aClient.endpointURL)"
+                     + (a2aClient.agentCard?.streaming == true ? " (streaming)" : ""))
+            status = .connected
+        } catch {
+            status = .error(error.localizedDescription)
+        }
+    }
+
+    private func submitQuery() {
+        let text = queryText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty, let client else { return }
+        queryText = ""
+        isSending = true
+        startLoadingAnimation()
+        logEntry(.outgoing, summary: "Query", detail: text)
+
+        Task {
+            defer {
+                isSending = false
+                stopLoadingAnimation()
+            }
+            if supportsStreaming {
+                await handleStream(client.sendTextStream(text, contextId: contextId), summary: "Response")
+            } else {
+                do {
+                    let result = try await client.sendText(text, contextId: contextId)
+                    contextId = result.contextId ?? contextId
+                    store.clearAll()
+                    processResult(result, summary: "Response")
+                } catch {
+                    logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func sendAction(_ action: ResolvedAction, surfaceId: String) async {
+        guard let client else { return }
+        isSending = true
+        startLoadingAnimation()
+        defer {
+            isSending = false
+            stopLoadingAnimation()
+        }
+
+        if supportsStreaming {
+            await handleStream(
+                client.sendActionStream(action, surfaceId: surfaceId, contextId: contextId),
+                summary: "Response to \(action.name)"
+            )
+        } else {
+            do {
+                let result = try await client.sendAction(action, surfaceId: surfaceId, contextId: contextId)
+                contextId = result.contextId ?? contextId
+                store.clearAll()
+                processResult(result, summary: "Response to \(action.name)")
+            } catch {
+                logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+            }
+        }
+    }
+
+    /// Consume SSE stream, show intermediate status, finalize with A2UI content.
+    private func handleStream(
+        _ stream: AsyncThrowingStream<StreamEvent, Error>,
+        summary: String
+    ) async {
+        var lastResult: SendResult?
+        var lastFinalText: String?
+        do {
+            for try await event in stream {
+                switch event {
+                case .status(let state, let text, _, let ctx, let isFinal):
+                    if let ctx { contextId = ctx }
+                    logEntry(.incoming, summary: "Stream [\(state.rawValue)]", detail: text ?? "")
+                    if isFinal, let text, !text.isEmpty {
+                        lastFinalText = text
+                    }
+                case .result(let result):
+                    if let ctx = result.contextId { contextId = ctx }
+                    lastResult = result
+                }
+            }
+            if let result = lastResult {
+                store.clearAll()
+                processResult(result, summary: summary)
+            } else if let text = lastFinalText {
+                store.clearAll()
+                logEntry(.incoming, summary: summary, detail: text)
+            } else {
+                logEntry(.incoming, summary: summary, detail: "Stream ended without result")
+            }
+        } catch {
+            logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+        }
+    }
+
+    private func processResult(_ result: SendResult, summary: String) {
+        hasResults = true
+        var errorCount = 0
+        for msg in result.messages {
+            do { try store.process(msg) } catch { errorCount += 1 }
+        }
+        logEntry(.incoming, summary: summary,
+                 detail: "Received \(result.messages.count) message(s), state: \(result.taskState.rawValue)"
+                 + (errorCount > 0 ? ", \(errorCount) skipped" : ""))
+    }
+
+    // MARK: - Loading Animation
+
+    private func startLoadingAnimation() {
+        loadingTextIndex = 0
+        loadingTimer?.invalidate()
+        loadingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+            loadingTextIndex = (loadingTextIndex + 1) % loadingTexts.count
+        }
+    }
+
+    private func stopLoadingAnimation() {
+        loadingTimer?.invalidate()
+        loadingTimer = nil
+    }
+
+    // MARK: - Logging
+
+    private func logAction(_ action: ResolvedAction, surfaceId: String) {
+        let contextStr = action.context.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        logEntry(.outgoing, summary: "\(action.name) [\(surfaceId)]", detail: contextStr)
+    }
+
+    private func logEntry(_ direction: ActionLogEntry.Direction, summary: String, detail: String) {
+        actionLog.append(ActionLogEntry(direction: direction, summary: summary, detail: detail))
+    }
+}
+
+// MARK: - Supporting Types
+
+private enum ConnectionStatus {
+    case idle, connecting, connected, error(String)
+
+    func subtitle(url: URL) -> String {
+        switch self {
+        case .idle: return url.absoluteString
+        case .connecting: return "Connecting to \(url.host() ?? url.absoluteString)..."
+        case .connected: return "Connected"
+        case .error(let msg): return "Error: \(msg)"
+        }
+    }
+}
+
+private struct ActionLogEntry: Identifiable {
+    let id = UUID()
+    let direction: Direction
+    let summary: String
+    let detail: String
+    let timestamp = Date()
+
+    enum Direction { case outgoing, incoming }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/AgentChatPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/AgentChatPage.swift
@@ -1,0 +1,485 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+/// Chat-style agent page: conversation with message history.
+///
+/// - Bottom chat input bar
+/// - Messages accumulate in a scrollable list
+/// - Agent responses embed A2UI surfaces inline within chat bubbles
+struct AgentChatPage: View {
+    let title: String
+    let agentURL: URL
+
+    @State private var client: A2AClient?
+    @State private var status: ConnectionStatus = .idle
+    @State private var chatMessages: [ChatMessage] = []
+    @State private var inputText = ""
+    @State private var isSending = false
+    @State private var contextId: String?
+    @State private var showLog = false
+    @State private var actionLog: [ActionLogEntry] = []
+
+    private let initialQuery: String?
+
+    init(title: String, agentURL: URL, initialQuery: String? = nil) {
+        self.title = title
+        self.agentURL = agentURL
+        self.initialQuery = initialQuery
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            connectedContent
+        }
+        .navigationTitle(title)
+#if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle(status.subtitle(url: agentURL))
+#endif
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showLog.toggle()
+                } label: {
+                    Label("Log", systemImage: "list.bullet.rectangle")
+                }
+#if !os(tvOS)
+                .badge(actionLog.count)
+#endif
+                .id(actionLog.count)
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showLog) {
+            logView
+                .inspectorColumnWidth(min: 260, ideal: 320, max: 450)
+        }
+#endif
+        .task { await connect() }
+    }
+
+    // MARK: - Connected Content
+
+    private var connectedContent: some View {
+        VStack(spacing: 0) {
+            messageList
+            Divider()
+            chatBar
+        }
+    }
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 16) {
+                    if chatMessages.isEmpty {
+                        if case .error(let msg) = status {
+                            ContentUnavailableView(
+                                "Connection Failed",
+                                systemImage: "wifi.exclamationmark",
+                                description: Text(msg)
+                            )
+                            .padding(.top, 60)
+                        }
+                    }
+                    ForEach(chatMessages) { msg in
+                        chatBubble(msg)
+                            .id(msg.id)
+                    }
+                }
+                .padding()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onChange(of: chatMessages.count) {
+                if let last = chatMessages.last {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func chatBubble(_ msg: ChatMessage) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            if msg.role == .agent {
+                Image(systemName: "cpu")
+                    .font(.title3)
+                    .foregroundStyle(.tint)
+                    .frame(width: 28)
+            }
+
+            VStack(alignment: msg.role == .user ? .trailing : .leading, spacing: 8) {
+                if let text = msg.text {
+                    Text(text)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 10)
+                        .background(msg.role == .user ? AnyShapeStyle(.tint) : AnyShapeStyle(.fill.quaternary))
+                        .foregroundStyle(msg.role == .user ? .white : .primary)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+
+                if let store = msg.surfaceStore {
+                    ForEach(store.orderedSurfaceIds, id: \.self) { surfaceId in
+                        if let vm = store.viewModels[surfaceId] {
+                            A2UISurfaceView(viewModel: vm, catalog: RizzCustomCatalog(), scrolls: false) { action in
+                                logAction(action, surfaceId: surfaceId)
+                                Task { await handleAction(action, surfaceId: surfaceId, messageId: msg.id) }
+                            }
+                            .padding(12)
+                            .background(.fill.quaternary)
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                        }
+                    }
+                }
+
+                if msg.isLoading {
+                    HStack(spacing: 6) {
+                        ProgressView().controlSize(.small)
+                        Text(msg.statusText ?? "Thinking…")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.15), value: msg.statusText)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: msg.role == .user ? .trailing : .leading)
+
+            if msg.role == .user {
+                Image(systemName: "person.crop.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28)
+            }
+        }
+    }
+
+    private var isInputDisabled: Bool {
+        isSending || client == nil
+    }
+
+    private var chatBar: some View {
+        HStack(spacing: 8) {
+            TextField(client == nil ? "Connecting…" : "Send a message…", text: $inputText)
+#if !os(tvOS)
+                .textFieldStyle(.roundedBorder)
+#endif
+                .onSubmit { sendMessage() }
+                .disabled(isInputDisabled)
+
+            Button {
+                sendMessage()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.title2)
+            }
+            .disabled(inputText.trimmingCharacters(in: .whitespaces).isEmpty || isInputDisabled)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Log
+
+    private var logView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Action Log", systemImage: "list.bullet.rectangle")
+                    .font(.subheadline.bold())
+                Spacer()
+                if !actionLog.isEmpty {
+                    Button("Clear") { actionLog.removeAll() }
+                        .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            if actionLog.isEmpty {
+                Text("Interact with components to see actions here.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(actionLog) { entry in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Image(systemName: entry.direction == .outgoing
+                                  ? "arrow.up.circle.fill"
+                                  : "arrow.down.circle.fill")
+                            .foregroundStyle(entry.direction == .outgoing ? .blue : .green)
+                            Text(entry.summary).font(.subheadline).bold()
+                            Spacer()
+                            Text(entry.timestamp, style: .time)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        if !entry.detail.isEmpty {
+                            Text(entry.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(4)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Networking
+
+    private func connect() async {
+        status = .connecting
+        do {
+            let a2aClient = try await A2AClient.fromBaseURL(agentURL)
+            client = a2aClient
+            let streamLabel = a2aClient.agentCard?.streaming == true ? " (streaming)" : ""
+            logEntry(.incoming, summary: "Connected",
+                     detail: "\(a2aClient.agentCard?.name ?? "Agent") at \(a2aClient.endpointURL)\(streamLabel)")
+        } catch {
+            client = A2AClient(endpointURL: agentURL)
+            logEntry(.incoming, summary: "Connected (direct)",
+                     detail: "Agent card unavailable, using \(agentURL) directly")
+        }
+        status = .connected
+
+        if let query = initialQuery, !query.isEmpty {
+            await sendText(query)
+        }
+    }
+
+    private func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        inputText = ""
+        Task { await sendText(text) }
+    }
+
+    private var supportsStreaming: Bool {
+        client?.agentCard?.streaming == true
+    }
+
+    private func sendText(_ text: String) async {
+        guard let client else { return }
+        isSending = true
+        defer { isSending = false }
+
+        let userMsg = ChatMessage(role: .user, text: text)
+        chatMessages.append(userMsg)
+
+        let placeholderId = UUID()
+        let placeholder = ChatMessage(id: placeholderId, role: .agent, isLoading: true)
+        chatMessages.append(placeholder)
+
+        logEntry(.outgoing, summary: "Text", detail: text)
+
+        if supportsStreaming {
+            await handleStream(
+                client.sendTextStream(text, contextId: contextId),
+                placeholderId: placeholderId,
+                actionName: nil
+            )
+        } else {
+            do {
+                let result = try await client.sendText(text, contextId: contextId)
+                contextId = result.contextId ?? contextId
+                replacePlaceholder(placeholderId, with: buildAgentMessage(from: result))
+                logEntry(.incoming, summary: "Response",
+                         detail: "\(result.messages.count) message(s), state: \(result.taskState.rawValue)")
+            } catch {
+                replacePlaceholder(placeholderId, with: ChatMessage(role: .agent, text: "Error: \(error.localizedDescription)"))
+                logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+            }
+        }
+    }
+
+    private func handleAction(_ action: ResolvedAction, surfaceId: String, messageId: UUID) async {
+        guard let client else { return }
+        isSending = true
+        defer { isSending = false }
+
+        let placeholderId = UUID()
+        let placeholder = ChatMessage(id: placeholderId, role: .agent, isLoading: true)
+        chatMessages.append(placeholder)
+
+        logEntry(.outgoing, summary: "\(action.name) [\(surfaceId)]",
+                 detail: action.context.map { "\($0.key): \($0.value)" }.joined(separator: ", "))
+
+        if supportsStreaming {
+            await handleStream(
+                client.sendActionStream(action, surfaceId: surfaceId, contextId: contextId),
+                placeholderId: placeholderId,
+                actionName: action.name
+            )
+        } else {
+            do {
+                let result = try await client.sendAction(action, surfaceId: surfaceId, contextId: contextId)
+                contextId = result.contextId ?? contextId
+                replacePlaceholder(placeholderId, with: buildAgentMessage(from: result))
+                logEntry(.incoming, summary: "Response to \(action.name)",
+                         detail: "\(result.messages.count) message(s), state: \(result.taskState.rawValue)")
+            } catch {
+                replacePlaceholder(placeholderId, with: ChatMessage(role: .agent, text: "Error: \(error.localizedDescription)"))
+                logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+            }
+        }
+    }
+
+    /// Consume SSE stream events, update the placeholder in real-time with status text,
+    /// and finalize with A2UI content when the result arrives.
+    private func handleStream(
+        _ stream: AsyncThrowingStream<StreamEvent, Error>,
+        placeholderId: UUID,
+        actionName: String?
+    ) async {
+        var lastResult: SendResult?
+        var lastFinalText: String?
+        let label = actionName.map { "Response to \($0)" } ?? "Response"
+
+        do {
+            for try await event in stream {
+                switch event {
+                case .status(let state, let text, _, let ctx, let isFinal):
+                    if let ctx { contextId = ctx }
+                    let statusText = text ?? state.rawValue
+                    updatePlaceholderStatus(placeholderId, text: statusText)
+                    logEntry(.incoming, summary: "Stream [\(state.rawValue)]", detail: text ?? "")
+                    if isFinal, let text, !text.isEmpty {
+                        lastFinalText = text
+                    }
+
+                case .result(let result):
+                    if let ctx = result.contextId { contextId = ctx }
+                    lastResult = result
+                }
+            }
+
+            if let result = lastResult {
+                replacePlaceholder(placeholderId, with: buildAgentMessage(from: result))
+                logEntry(.incoming, summary: label,
+                         detail: "\(result.messages.count) message(s), state: \(result.taskState.rawValue)")
+            } else if let text = lastFinalText {
+                replacePlaceholder(placeholderId, with: ChatMessage(role: .agent, text: text))
+                logEntry(.incoming, summary: label, detail: text)
+            } else {
+                replacePlaceholder(placeholderId, with: ChatMessage(role: .agent, text: "Stream ended without result."))
+                logEntry(.incoming, summary: label, detail: "No result in stream")
+            }
+        } catch {
+            replacePlaceholder(placeholderId, with: ChatMessage(role: .agent, text: "Error: \(error.localizedDescription)"))
+            logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+        }
+    }
+
+    private func updatePlaceholderStatus(_ id: UUID, text: String) {
+        if let idx = chatMessages.firstIndex(where: { $0.id == id }) {
+            chatMessages[idx].statusText = text
+        }
+    }
+
+    private func buildAgentMessage(from result: SendResult) -> ChatMessage {
+        if result.messages.isEmpty {
+            return ChatMessage(role: .agent, text: "No response from agent.")
+        }
+        let store = SurfaceStore()
+        var errorDetails: [String] = []
+        for (i, msg) in result.messages.enumerated() {
+            do {
+                try store.process(msg)
+            } catch {
+                errorDetails.append("Message[\(i)] failed: \(error)")
+            }
+        }
+        if !errorDetails.isEmpty {
+            return ChatMessage(role: .agent, text: errorDetails.joined(separator: "\n"), surfaceStore: store)
+        }
+        return ChatMessage(role: .agent, surfaceStore: store)
+    }
+
+    private func replacePlaceholder(_ id: UUID, with message: ChatMessage) {
+        if let idx = chatMessages.firstIndex(where: { $0.id == id }) {
+            chatMessages[idx] = message
+        } else {
+            chatMessages.append(message)
+        }
+    }
+
+    // MARK: - Logging
+
+    private func logAction(_ action: ResolvedAction, surfaceId: String) {
+        let contextStr = action.context.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        logEntry(.outgoing, summary: "\(action.name) [\(surfaceId)]", detail: contextStr)
+    }
+
+    private func logEntry(_ direction: ActionLogEntry.Direction, summary: String, detail: String) {
+        actionLog.append(ActionLogEntry(direction: direction, summary: summary, detail: detail))
+    }
+}
+
+// MARK: - Supporting Types
+
+private struct ChatMessage: Identifiable {
+    let id: UUID
+    let role: Role
+    var text: String?
+    var surfaceStore: SurfaceStore?
+    var isLoading: Bool
+    var statusText: String?
+
+    init(id: UUID = UUID(), role: Role, text: String? = nil,
+         surfaceStore: SurfaceStore? = nil, isLoading: Bool = false,
+         statusText: String? = nil) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.surfaceStore = surfaceStore
+        self.isLoading = isLoading
+        self.statusText = statusText
+    }
+
+    enum Role { case user, agent }
+}
+
+private enum ConnectionStatus {
+    case idle, connecting, connected, error(String)
+
+    func subtitle(url: URL) -> String {
+        switch self {
+        case .idle: return url.absoluteString
+        case .connecting: return "Connecting to \(url.host() ?? url.absoluteString)…"
+        case .connected: return "Connected · \(url.absoluteString)"
+        case .error(let msg): return "Error: \(msg)"
+        }
+    }
+}
+
+private struct ActionLogEntry: Identifiable {
+    let id = UUID()
+    let direction: Direction
+    let summary: String
+    let detail: String
+    let timestamp = Date()
+
+    enum Direction { case outgoing, incoming }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/CatalogPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/CatalogPage.swift
@@ -1,0 +1,553 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+// MARK: - Catalog Page
+
+struct CatalogPage: View {
+    @State private var showingInspector = false
+    @State private var inspectedEntry: CatalogEntry?
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                ForEach(componentCatalog) { entry in
+                    catalogCard(entry)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Component Gallery")
+        #if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle("Building blocks and examples for Agent Driven UIs")
+        #endif
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingInspector.toggle()
+                } label: {
+                    Label("About", systemImage: "info.circle")
+                }
+            }
+        }
+        .sheet(item: $inspectedEntry) { entry in
+            NavigationStack {
+                CatalogDetailPage(entry: entry)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { inspectedEntry = nil }
+                        }
+                    }
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showingInspector) {
+            ScrollView {
+                Text("A gallery of all A2UI standard components rendered by the SwiftUI renderer. Each card is live-rendered from static v0.9 JSON. Tap the detail button to inspect source JSON.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 400)
+        }
+#endif
+    }
+
+    @ViewBuilder
+    private func catalogCard(_ entry: CatalogEntry) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(entry.name)
+                    .font(.title3)
+                    .fontWeight(.medium)
+                Spacer()
+                Button {
+                    inspectedEntry = entry
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 4)
+
+            VStack {
+                if let vm = entry.viewModel {
+                    A2UISurfaceView(viewModel: vm, scrolls: false)
+                        .padding()
+                } else {
+                    Text("Failed to parse")
+                        .foregroundStyle(.red)
+                        .padding()
+                }
+            }
+            #if os(iOS)
+            .background(Color(.secondarySystemGroupedBackground))
+            #elseif os(macOS)
+            .background(Color(.windowBackgroundColor))
+            #elseif os(visionOS)
+            .background(.regularMaterial)
+            #else
+            .background(.ultraThinMaterial)
+            #endif
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            #if os(macOS)
+            .shadow(color: .black.opacity(0.08), radius: 2, y: 1)
+            #endif
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Detail Page
+
+struct CatalogDetailPage: View {
+    let entry: CatalogEntry
+    @State private var selectedTab = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("View", selection: $selectedTab) {
+                Text("Rendered").tag(0)
+                Text("JSON").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            Divider()
+
+            if selectedTab == 0 {
+                renderedView
+            } else {
+                jsonView
+            }
+        }
+        .navigationTitle(entry.name)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    @ViewBuilder
+    private var renderedView: some View {
+        if let vm = entry.viewModel {
+            A2UISurfaceView(viewModel: vm)
+        } else {
+            ContentUnavailableView(
+                "Parse Error",
+                systemImage: "exclamationmark.triangle",
+                description: Text("Failed to parse the JSON input.")
+            )
+        }
+    }
+
+    private var jsonView: some View {
+        ScrollView([.horizontal, .vertical]) {
+            Text(entry.prettyJSON)
+                .font(.system(.caption, design: .monospaced))
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        #if os(iOS)
+        .background(Color(.systemGray6))
+        #elseif os(macOS)
+        .background(Color(.textBackgroundColor))
+        #else
+        .background(.ultraThinMaterial)
+        #endif
+    }
+}
+
+// MARK: - Data
+
+struct CatalogEntry: Identifiable {
+    let name: String
+    let icon: String
+    let json: String
+    let viewModel: SurfaceViewModel?
+
+    var id: String { name }
+
+    var prettyJSON: String { prettyPrintedA2UIJSON(json) }
+
+    init(name: String, icon: String = "square", json: String) {
+        self.name = name
+        self.icon = icon
+        self.json = json
+        if let messages = try? DemoMessages.decode(Data(json.utf8)), !messages.isEmpty {
+            self.viewModel = makeSurfaceViewModel(from: messages)
+        } else {
+            self.viewModel = nil
+        }
+    }
+}
+
+// MARK: - Catalog Data
+
+private let CID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+
+let componentCatalog: [CatalogEntry] = [
+
+    CatalogEntry(name: "Text", icon: "textformat", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["h1","h2","h3","h4","h5","body","cap"]},
+      {"id":"h1","component":"Text","text":"Heading 1 — h1","variant":"h1"},
+      {"id":"h2","component":"Text","text":"Heading 2 — h2","variant":"h2"},
+      {"id":"h3","component":"Text","text":"Heading 3 — h3","variant":"h3"},
+      {"id":"h4","component":"Text","text":"Heading 4 — h4","variant":"h4"},
+      {"id":"h5","component":"Text","text":"Heading 5 — h5","variant":"h5"},
+      {"id":"body","component":"Text","text":"Body text — default","variant":"body"},
+      {"id":"cap","component":"Text","text":"Caption text — caption","variant":"caption"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Image", icon: "photo", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["sec_variants","row_small","header_img","sec_fit","fit_contain","fit_cover","fit_fill","fit_none","fit_scaledown"]},
+      {"id":"sec_variants","component":"Text","text":"Variants","variant":"h4"},
+      {"id":"row_small","component":"Row","children":["avatar","icon","small"],"align":"center"},
+      {"id":"avatar","component":"Image","url":"https://picsum.photos/id/64/200/200","variant":"avatar"},
+      {"id":"icon","component":"Image","url":"https://picsum.photos/id/76/200/200","variant":"icon"},
+      {"id":"small","component":"Image","url":"https://picsum.photos/id/82/200/200","variant":"smallFeature"},
+      {"id":"header_img","component":"Image","url":"https://picsum.photos/id/10/800/400","variant":"header","fit":"cover"},
+      {"id":"sec_fit","component":"Text","text":"Fit modes (same 600×300 image in a feature frame)","variant":"h4"},
+      {"id":"fit_contain","component":"Column","children":["fc_label","fc_img"]},
+      {"id":"fc_label","component":"Text","text":"contain — fit entirely, may letterbox","variant":"caption"},
+      {"id":"fc_img","component":"Image","url":"https://picsum.photos/id/11/600/300","variant":"mediumFeature","fit":"contain"},
+      {"id":"fit_cover","component":"Column","children":["fv_label","fv_img"]},
+      {"id":"fv_label","component":"Text","text":"cover — fill frame, may crop","variant":"caption"},
+      {"id":"fv_img","component":"Image","url":"https://picsum.photos/id/11/600/300","variant":"mediumFeature","fit":"cover"},
+      {"id":"fit_fill","component":"Column","children":["ff_label","ff_img"]},
+      {"id":"ff_label","component":"Text","text":"fill — stretch to frame, ignores aspect ratio","variant":"caption"},
+      {"id":"ff_img","component":"Image","url":"https://picsum.photos/id/11/600/300","variant":"mediumFeature","fit":"fill"},
+      {"id":"fit_none","component":"Column","children":["fn_label","fn_img"]},
+      {"id":"fn_label","component":"Text","text":"none — original size, no scaling","variant":"caption"},
+      {"id":"fn_img","component":"Image","url":"https://picsum.photos/id/11/600/300","variant":"mediumFeature","fit":"none"},
+      {"id":"fit_scaledown","component":"Column","children":["fs_label","fs_img"]},
+      {"id":"fs_label","component":"Text","text":"scaleDown — like contain, but never enlarges","variant":"caption"},
+      {"id":"fs_img","component":"Image","url":"https://picsum.photos/id/11/600/300","variant":"mediumFeature","fit":"scaleDown"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Icon", icon: "star.circle", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Row","children":["i1","i2","i3"],"justify":"spaceEvenly","align":"center"},
+      {"id":"i1","component":"Icon","name":"favorite"},
+      {"id":"i2","component":"Icon","name":"home"},
+      {"id":"i3","component":"Icon","name":"settings"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Divider", icon: "minus", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["sec_h","t1","dh","t2","sec_v","row_v"]},
+      {"id":"sec_h","component":"Text","text":"Horizontal (default)","variant":"h4"},
+      {"id":"t1","component":"Text","text":"Content above"},
+      {"id":"dh","component":"Divider"},
+      {"id":"t2","component":"Text","text":"Content below"},
+      {"id":"sec_v","component":"Text","text":"Vertical (axis)","variant":"h4"},
+      {"id":"row_v","component":"Row","children":["left","dv","right"],"align":"stretch"},
+      {"id":"left","component":"Text","text":"Left"},
+      {"id":"dv","component":"Divider","axis":"vertical"},
+      {"id":"right","component":"Text","text":"Right"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Row", icon: "arrow.left.and.right", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["lbl_default","row_default","lbl_center","row_center","lbl_between","row_between","lbl_evenly","row_evenly","lbl_end","row_end","lbl_align","row_align"]},
+      {"id":"lbl_default","component":"Text","text":"justify: start (default)","variant":"caption"},
+      {"id":"row_default","component":"Row","children":["d1","d2","d3"]},
+      {"id":"d1","component":"Text","text":"A"},{"id":"d2","component":"Text","text":"B"},{"id":"d3","component":"Text","text":"C"},
+      {"id":"lbl_center","component":"Text","text":"justify: center","variant":"caption"},
+      {"id":"row_center","component":"Row","children":["c1","c2","c3"],"justify":"center"},
+      {"id":"c1","component":"Text","text":"A"},{"id":"c2","component":"Text","text":"B"},{"id":"c3","component":"Text","text":"C"},
+      {"id":"lbl_between","component":"Text","text":"justify: spaceBetween","variant":"caption"},
+      {"id":"row_between","component":"Row","children":["b1","b2","b3"],"justify":"spaceBetween"},
+      {"id":"b1","component":"Text","text":"A"},{"id":"b2","component":"Text","text":"B"},{"id":"b3","component":"Text","text":"C"},
+      {"id":"lbl_evenly","component":"Text","text":"justify: spaceEvenly","variant":"caption"},
+      {"id":"row_evenly","component":"Row","children":["e1","e2","e3"],"justify":"spaceEvenly"},
+      {"id":"e1","component":"Text","text":"A"},{"id":"e2","component":"Text","text":"B"},{"id":"e3","component":"Text","text":"C"},
+      {"id":"lbl_end","component":"Text","text":"justify: end","variant":"caption"},
+      {"id":"row_end","component":"Row","children":["n1","n2","n3"],"justify":"end"},
+      {"id":"n1","component":"Text","text":"A"},{"id":"n2","component":"Text","text":"B"},{"id":"n3","component":"Text","text":"C"},
+      {"id":"lbl_align","component":"Text","text":"align: center (mixed height)","variant":"caption"},
+      {"id":"row_align","component":"Row","children":["a1","a2"],"align":"center"},
+      {"id":"a1","component":"Text","text":"Small"},
+      {"id":"a2","component":"Text","text":"Big Title","variant":"h2"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Column", icon: "arrow.up.and.down", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["lbl_justify","row_justify","lbl_align","col_align"]},
+      {"id":"lbl_justify","component":"Text","text":"justify: start / center / end","variant":"caption"},
+      {"id":"row_justify","component":"Row","children":["col_start","dv1","col_center","dv2","col_end"]},
+      {"id":"col_start","weight":1,"component":"Column","children":["ls","s1","s2","s3"],"justify":"start"},
+      {"id":"ls","component":"Text","text":"start","variant":"caption"},
+      {"id":"s1","component":"Text","text":"A"},{"id":"s2","component":"Text","text":"B"},{"id":"s3","component":"Text","text":"C"},
+      {"id":"dv1","component":"Divider","axis":"vertical"},
+      {"id":"col_center","weight":1,"component":"Column","children":["lc","c1","c2","c3"],"justify":"center"},
+      {"id":"lc","component":"Text","text":"center","variant":"caption"},
+      {"id":"c1","component":"Text","text":"A"},{"id":"c2","component":"Text","text":"B"},{"id":"c3","component":"Text","text":"C"},
+      {"id":"dv2","component":"Divider","axis":"vertical"},
+      {"id":"col_end","weight":1,"component":"Column","children":["le","e1","e2","e3"],"justify":"end"},
+      {"id":"le","component":"Text","text":"end","variant":"caption"},
+      {"id":"e1","component":"Text","text":"A"},{"id":"e2","component":"Text","text":"B"},{"id":"e3","component":"Text","text":"C"},
+      {"id":"lbl_align","component":"Text","text":"align: center","variant":"caption"},
+      {"id":"col_align","component":"Column","children":["aa1","aa2"],"align":"center"},
+      {"id":"aa1","component":"Text","text":"Short"},
+      {"id":"aa2","component":"Text","text":"A longer text to show cross-axis centering"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Card", icon: "rectangle.on.rectangle", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Card","child":"content"},
+      {"id":"content","component":"Column","children":["title","desc"]},
+      {"id":"title","component":"Text","text":"Card Title","variant":"h4"},
+      {"id":"desc","component":"Text","text":"This is a card with some content inside."}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Button", icon: "rectangle.and.hand.point.up.left", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Row","children":["b1","b2"]},
+      {"id":"b1","component":"Button","child":"bt1","variant":"primary","action":{"event":{"name":"tap1"}}},
+      {"id":"bt1","component":"Text","text":"Primary"},
+      {"id":"b2","component":"Button","child":"bt2","action":{"event":{"name":"tap2"}}},
+      {"id":"bt2","component":"Text","text":"Default"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "TextField", icon: "character.cursor.ibeam", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["tf_short","tf_num","tf_pw","tf_long","tf_regex"]},
+      {"id":"tf_short","component":"TextField","label":"Name","value":{"path":"/name"}},
+      {"id":"tf_num","component":"TextField","label":"Age","value":{"path":"/age"},"variant":"number"},
+      {"id":"tf_pw","component":"TextField","label":"Password","value":{"path":"/pw"},"variant":"obscured"},
+      {"id":"tf_long","component":"TextField","label":"Bio","value":{"path":"/bio"},"variant":"longText"},
+      {"id":"tf_regex","component":"TextField","label":"Email","value":{"path":"/email"},"validationRegexp":"^[\\\\w.+-]+@[\\\\w-]+\\\\.[a-zA-Z]{2,}$"}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"name":"Jane Doe","age":"28","pw":"secret","bio":"Hello world","email":"jane@example.com"}}}
+    ]
+    """),
+
+    CatalogEntry(name: "CheckBox", icon: "checkmark.square", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["cb1","cb2"]},
+      {"id":"cb1","component":"CheckBox","label":"Accept Terms","value":{"path":"/terms"}},
+      {"id":"cb2","component":"CheckBox","label":"Subscribe to Newsletter","value":{"path":"/newsletter"}}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"terms":true,"newsletter":false}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Slider", icon: "slider.horizontal.3", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["s"]},
+      {"id":"s","component":"Slider","label":"Volume","value":{"path":"/volume"},"min":0,"max":100}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"volume":50}}}
+    ]
+    """),
+
+    CatalogEntry(name: "List (Vertical)", icon: "list.bullet", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"List","children":["l1","l2","l3"],"direction":"vertical"},
+      {"id":"l1","component":"Text","text":"Item 1"},
+      {"id":"l2","component":"Text","text":"Item 2"},
+      {"id":"l3","component":"Text","text":"Item 3"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "List (Horizontal)", icon: "list.bullet.indent", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"List","children":["h1","h2","h3","h4","h5"],"direction":"horizontal"},
+      {"id":"h1","component":"Card","child":"ht1"},{"id":"ht1","component":"Text","text":"Card A"},
+      {"id":"h2","component":"Card","child":"ht2"},{"id":"ht2","component":"Text","text":"Card B"},
+      {"id":"h3","component":"Card","child":"ht3"},{"id":"ht3","component":"Text","text":"Card C"},
+      {"id":"h4","component":"Card","child":"ht4"},{"id":"ht4","component":"Text","text":"Card D"},
+      {"id":"h5","component":"Card","child":"ht5"},{"id":"ht5","component":"Text","text":"Card E"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "DateTimeInput", icon: "calendar", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Column","children":["dt1","dt2","dt3"]},
+      {"id":"dt1","component":"DateTimeInput","label":"Date only","value":{"path":"/date"},"enableDate":true,"enableTime":false},
+      {"id":"dt2","component":"DateTimeInput","label":"Time only","value":{"path":"/time"},"enableDate":false,"enableTime":true},
+      {"id":"dt3","component":"DateTimeInput","label":"Date & Time","value":{"path":"/datetime"},"enableDate":true,"enableTime":true}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"date":"2025-12-09","time":"14:30:00","datetime":"2025-12-09T14:30:00"}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Single Select — Picker", icon: "circle.inset.filled", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Show scroll bars","value":{"path":"/singleRadio"},"variant":"mutuallyExclusive","displayStyle":"checkbox","options":[
+        {"label":"Automatically based on mouse or trackpad","value":"auto"},
+        {"label":"When scrolling","value":"scroll"},
+        {"label":"Always","value":"always"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"singleRadio":["auto"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Single Select — Chips", icon: "tag", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Pick one size","value":{"path":"/singleChips"},"variant":"mutuallyExclusive","displayStyle":"chips","options":[
+        {"label":"Small","value":"S"},{"label":"Medium","value":"M"},{"label":"Large","value":"L"},{"label":"XL","value":"XL"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"singleChips":["M"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Multi Select — Checkbox", icon: "checklist", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Select toppings","value":{"path":"/multiCB"},"variant":"multipleSelection","displayStyle":"checkbox","options":[
+        {"label":"Cheese","value":"cheese"},{"label":"Pepperoni","value":"pepperoni"},{"label":"Mushrooms","value":"mushrooms"},{"label":"Olives","value":"olives"},{"label":"Onions","value":"onions"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"multiCB":["cheese","mushrooms"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Multi Select — Chips", icon: "tag.fill", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Select tags","value":{"path":"/multiChips"},"variant":"multipleSelection","displayStyle":"chips","options":[
+        {"label":"Work","value":"work"},{"label":"Home","value":"home"},{"label":"Urgent","value":"urgent"},{"label":"Later","value":"later"},{"label":"Fun","value":"fun"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"multiChips":["work","urgent"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Filterable — Checkbox", icon: "line.3.horizontal.decrease.circle", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Select countries","value":{"path":"/filterCB"},"variant":"multipleSelection","displayStyle":"checkbox","filterable":true,"options":[
+        {"label":"United States","value":"US"},{"label":"Canada","value":"CA"},{"label":"United Kingdom","value":"UK"},{"label":"Australia","value":"AU"},{"label":"Germany","value":"DE"},{"label":"France","value":"FR"},{"label":"Japan","value":"JP"},{"label":"South Korea","value":"KR"},{"label":"Brazil","value":"BR"},{"label":"India","value":"IN"},{"label":"Mexico","value":"MX"},{"label":"Italy","value":"IT"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"filterCB":["US"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Filterable — Chips", icon: "line.3.horizontal.decrease.circle.fill", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)","sendDataModel":true}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"ChoicePicker","label":"Select languages","value":{"path":"/filterChips"},"variant":"multipleSelection","displayStyle":"chips","filterable":true,"options":[
+        {"label":"Swift","value":"swift"},{"label":"Python","value":"python"},{"label":"Rust","value":"rust"},{"label":"Go","value":"go"},{"label":"TypeScript","value":"typescript"},{"label":"Kotlin","value":"kotlin"},{"label":"Java","value":"java"},{"label":"C++","value":"cpp"},{"label":"Ruby","value":"ruby"},{"label":"Haskell","value":"haskell"},{"label":"Scala","value":"scala"},{"label":"Elixir","value":"elixir"},{"label":"Dart","value":"dart"},{"label":"Zig","value":"zig"}
+      ]}
+    ]}},
+    {"version":"v0.9","updateDataModel":{"surfaceId":"main","value":{"filterChips":["swift","rust"]}}}
+    ]
+    """),
+
+    CatalogEntry(name: "Tabs", icon: "rectangle.split.3x1", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Tabs","tabs":[{"title":"View One","child":"t1"},{"title":"View Two","child":"t2"}]},
+      {"id":"t1","component":"Text","text":"First tab content"},
+      {"id":"t2","component":"Text","text":"Second tab content"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Modal", icon: "rectangle.portrait.on.rectangle.portrait", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Modal","trigger":"mbtn","content":"mcol"},
+      {"id":"mbtn","component":"Button","child":"mbtn-text","action":{"event":{"name":"open_modal"}}},
+      {"id":"mbtn-text","component":"Text","text":"Open Modal"},
+      {"id":"mcol","component":"Column","children":["mh","mp","mclose"]},
+      {"id":"mh","component":"Text","text":"Modal Title","variant":"h3"},
+      {"id":"mp","component":"Text","text":"This is a modal dialog with rich content. Tap the close button to dismiss."},
+      {"id":"mclose","component":"Button","child":"mclose-text","action":{"event":{"name":"dismiss_modal"}}},
+      {"id":"mclose-text","component":"Text","text":"Got it"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "Video", icon: "play.rectangle", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"Video","url":"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"}
+    ]}}
+    ]
+    """),
+
+    CatalogEntry(name: "AudioPlayer", icon: "waveform", json: """
+    [
+    {"version":"v0.9","createSurface":{"surfaceId":"main","catalogId":"\(CID)"}},
+    {"version":"v0.9","updateComponents":{"surfaceId":"main","components":[
+      {"id":"root","component":"AudioPlayer","url":"https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3","description":"Sample Audio Track"}
+    ]}}
+    ]
+    """),
+
+]
+
+#Preview {
+    NavigationStack {
+        CatalogPage()
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/CustomComponentPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/CustomComponentPage.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+struct CustomComponentPage: View {
+    private static let json = """
+    [
+      { "version": "v0.9", "createSurface": { "surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json", "sendDataModel": true } },
+      { "version": "v0.9", "updateComponents": { "surfaceId": "main", "components": [
+        { "id": "root", "component": "Column", "children": ["name", "bio", "slider"], "align": "stretch" },
+        { "id": "name", "component": "Text", "text": { "path": "/name" }, "variant": "h3" },
+        { "id": "bio", "component": "Text", "text": { "path": "/bio" } },
+        { "id": "slider", "component": "Slider", "label": "Rating", "value": { "path": "/rating" }, "min": 0, "max": 5 }
+      ] } },
+      { "version": "v0.9", "updateDataModel": { "surfaceId": "main", "value": { "name": "Alice Johnson", "bio": "iOS developer & SwiftUI enthusiast.", "rating": 3 } } }
+    ]
+    """
+
+    private static func makeViewModel() -> SurfaceViewModel {
+        let messages = (try? DemoMessages.decode(Data(json.utf8))) ?? []
+        return makeSurfaceViewModel(from: messages)
+    }
+
+    @State private var viewModel = makeViewModel()
+    @State private var showingInspector = false
+
+    var body: some View {
+        List {
+            Section("A2UI Components") {
+                A2UISurfaceView(viewModel: viewModel, scrolls: false)
+            }
+
+            Section("Custom Native Component") {
+                StarRatingView(viewModel: viewModel, path: "/rating")
+            }
+        }
+        .navigationTitle("Custom Component")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingInspector.toggle()
+                } label: {
+                    Label("About", systemImage: "info.circle")
+                }
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showingInspector) {
+            ScrollView {
+                Text("Demonstrates a custom native SwiftUI view (star rating) that reads and writes the same A2UI data model as standard components. Drag the slider or tap a star — both update the /rating path.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 400)
+        }
+#endif
+    }
+}
+
+/// A fully native SwiftUI view that reads and writes the A2UI data model.
+/// Drag the slider above or tap a star — both update the same `/rating` path.
+private struct StarRatingView: View {
+    let viewModel: SurfaceViewModel
+    let path: String
+
+    private var rating: Int {
+        let dc = viewModel.makeDataContext()
+        if let value = dc.resolve(DynamicNumber.dataBinding(path: path)) {
+            return max(0, min(5, Int(value.rounded())))
+        }
+        return 0
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(1...5, id: \.self) { star in
+                Image(systemName: star <= rating ? "star.fill" : "star")
+                    .foregroundStyle(star <= rating ? .yellow : .gray.opacity(0.4))
+                    .onTapGesture {
+                        try? viewModel.makeDataContext().set(path, value: .number(Double(star)))
+                    }
+            }
+        }
+        .font(.title2)
+        .accessibilityElement()
+        .accessibilityLabel("Rating: \(rating) of 5")
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/IncrementalUpdatePage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/IncrementalUpdatePage.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+struct IncrementalUpdatePage: View {
+    @State private var viewModel = IncrementalUpdatePage.makeViewModel()
+    @State private var allMessages: [A2uiMessage] = []
+    @State private var currentStep = 0
+    @State private var errorText: String?
+    @State private var showingInspector = false
+
+    private let stepDescriptions = [
+        "Step 1: createSurface — create surface",
+        "Step 2: ADD — title + Message A",
+        "Step 3: ADD — Message B, C",
+        "Step 4: REPLACE — edit Message A",
+        "Step 5: DELETE — remove Message B"
+    ]
+
+    private var totalSteps: Int { allMessages.count }
+
+    private static func makeViewModel() -> SurfaceViewModel {
+        SurfaceViewModel(surface: SurfaceModel(id: "main", catalog: demoCatalog))
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Text(currentStep > 0 && currentStep <= stepDescriptions.count
+                     ? stepDescriptions[currentStep - 1]
+                     : "Tap Next Step to begin")
+                .foregroundStyle(.secondary)
+            } header: {
+                Text("Progress: \(currentStep) / \(totalSteps)")
+            }
+
+            if viewModel.componentTree != nil {
+                Section("Rendered") {
+                    A2UISurfaceView(viewModel: viewModel, scrolls: false)
+                }
+            }
+
+            if let errorText {
+                Section { Text(errorText).foregroundStyle(.red) }
+            }
+        }
+        .navigationTitle("Incremental Update")
+#if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle("Step-by-step component add, replace & delete")
+#endif
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Next Step") { applyNextStep() }
+                    .disabled(currentStep >= totalSteps)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Reset") { resetAll() }
+            }
+#if !os(visionOS) && !os(tvOS)
+            ToolbarItem(placement: .secondaryAction) {
+                Button {
+                    showingInspector.toggle()
+                } label: {
+                    Label("About", systemImage: "info.circle")
+                }
+            }
+#endif
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showingInspector) {
+            ScrollView {
+                Text("Demonstrates incremental UI updates via the v0.9 updateComponents message. Each step sends a single message that adds, replaces, or removes components from the surface without a full re-render.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 400)
+        }
+#endif
+        .task { loadMessages() }
+    }
+
+    private func loadMessages() {
+        do {
+            allMessages = try DemoMessages.load("incremental_update")
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+
+    private func applyNextStep() {
+        guard currentStep < totalSteps else { return }
+        do {
+            try viewModel.processMessage(allMessages[currentStep])
+            currentStep += 1
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+
+    private func resetAll() {
+        viewModel = Self.makeViewModel()
+        currentStep = 0
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/LiveAgentPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/LiveAgentPage.swift
@@ -1,0 +1,395 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+// Mirrors the DEMO_ITEMS array from the official Lit component-gallery.
+private struct DemoItem: Identifiable {
+    let id: String        // surfaceId from agent
+    let title: String
+    let description: String
+    let dataPath: String? // non-nil → show "Log Value" button
+}
+
+private let demoItems: [DemoItem] = [
+    .init(id: "demo-text", title: "TextField", description: "Allows user to enter text. Supports binding to data model.", dataPath: "/galleryData/textField"),
+    .init(id: "demo-text-regex", title: "TextField (Regex)", description: "TextField with 5-digit regex validation.", dataPath: "/galleryData/textFieldRegex"),
+    .init(id: "demo-checkbox", title: "CheckBox", description: "A binary toggle.", dataPath: "/galleryData/checkbox"),
+    .init(id: "demo-slider", title: "Slider", description: "Select a value from a range.", dataPath: "/galleryData/slider"),
+    .init(id: "demo-date", title: "DateTimeInput", description: "Pick a date or time.", dataPath: "/galleryData/date"),
+    .init(id: "demo-mc-single-checkbox", title: "Single Select — Picker", description: "Pick one (Picker/Radio).", dataPath: "/galleryData/singleCheckbox"),
+    .init(id: "demo-mc-single-chips", title: "Single Select — Chips", description: "Pick one (Chips).", dataPath: "/galleryData/singleChips"),
+    .init(id: "demo-mc-multi-checkbox", title: "Multi Select — Checkbox", description: "Select multiple (Checkmark).", dataPath: "/galleryData/multiCheckbox"),
+    .init(id: "demo-mc-multi-chips", title: "Multi Select — Chips", description: "Select multiple (Chips).", dataPath: "/galleryData/multiChips"),
+    .init(id: "demo-mc-filter-checkbox", title: "Filterable — Checkbox", description: "Search and filter (Checkmark).", dataPath: "/galleryData/filterCheckbox"),
+    .init(id: "demo-mc-filter-chips", title: "Filterable — Chips", description: "Search and filter (Chips).", dataPath: "/galleryData/filterChips"),
+    .init(id: "demo-image", title: "Image", description: "Displays an image from a URL.", dataPath: nil),
+    .init(id: "demo-button", title: "Button", description: "Triggers a client-side action.", dataPath: nil),
+    .init(id: "demo-tabs", title: "Tabs", description: "Switch between different views.", dataPath: nil),
+    .init(id: "demo-icon", title: "Icon", description: "Standard icons.", dataPath: nil),
+    .init(id: "demo-divider", title: "Divider", description: "Visual separation.", dataPath: nil),
+    .init(id: "demo-card", title: "Card", description: "A container for other components.", dataPath: nil),
+    .init(id: "demo-video", title: "Video", description: "Video player.", dataPath: nil),
+    .init(id: "demo-modal", title: "Modal", description: "Overlay dialog.", dataPath: nil),
+    .init(id: "demo-list", title: "List", description: "Vertical or horizontal list.", dataPath: nil),
+    .init(id: "demo-audio", title: "AudioPlayer", description: "Play audio content.", dataPath: nil),
+]
+
+struct LiveAgentPage: View {
+    let agentURL: URL
+    let initialQuery: String
+
+    @State private var store = SurfaceStore()
+    @State private var client: A2AClient?
+    @State private var status: ConnectionStatus = .idle
+    @State private var actionLog: [ActionLogEntry] = []
+    @State private var inspectorMode: InspectorMode?
+
+    var body: some View {
+        Group {
+            switch status {
+            case .idle, .connecting:
+                ProgressView("Connecting to Agent…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .connected:
+                connectedContent
+            case .error(let message):
+                ContentUnavailableView(
+                    "Connection Failed",
+                    systemImage: "wifi.exclamationmark",
+                    description: Text(message)
+                )
+            }
+        }
+        .navigationTitle("Live Agent")
+#if !os(visionOS) && !os(tvOS)
+        .navigationSubtitle(status.subtitle(url: agentURL))
+#endif
+#if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+#endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                HStack(spacing: 4) {
+                    Button {
+                        inspectorMode = inspectorMode == .info ? nil : .info
+                    } label: {
+                        Label("About", systemImage: "info.circle")
+                    }
+                    Button {
+                        inspectorMode = inspectorMode == .log ? nil : .log
+                    } label: {
+                        Label("Log", systemImage: "list.bullet.rectangle")
+                    }
+#if !os(tvOS)
+                    .badge(actionLog.count)
+#endif
+                }
+                .id(actionLog.count)
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: Binding(
+            get: { inspectorMode != nil },
+            set: { if !$0 { inspectorMode = nil } }
+        )) {
+            Group {
+                switch inspectorMode {
+                case .info:
+                    aboutView
+                case .log:
+                    actionLogView
+                case nil:
+                    EmptyView()
+                }
+            }
+            .inspectorColumnWidth(min: 260, ideal: 320, max: 450)
+        }
+        .task { await connect() }
+#endif
+    }
+
+    // MARK: - Connected Layout
+
+    private var connectedContent: some View {
+        galleryPane
+    }
+
+    private var galleryPane: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(demoItems) { item in
+                    demoCard(for: item)
+                }
+            }
+            .padding()
+        }
+    }
+
+    @ViewBuilder
+    private func demoCard(for item: DemoItem) -> some View {
+        let vm = store.viewModels[item.id]
+
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.headline)
+                Text(item.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            if let vm {
+                A2UISurfaceView(viewModel: vm, catalog: RizzCustomCatalog(), scrolls: false) { action in
+                    logAction(action, surfaceId: item.id)
+                    Task { await sendAction(action, surfaceId: item.id) }
+                }
+            } else {
+                Text("Surface not loaded")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if let dataPath = item.dataPath, let vm {
+                Divider()
+                HStack {
+                    Spacer()
+                    Button("Log Value") {
+                        logDataValue(vm: vm, path: dataPath, item: item)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+        }
+        .padding()
+        .background(.background.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - About Inspector
+
+    private var aboutView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Component Gallery Agent")
+                    .font(.title3.bold())
+
+                Text("This page connects to the Component Gallery Agent — a deterministic (non-AI) A2UI server that returns hardcoded JSON for all standard components.")
+
+                if let vm = store.viewModels["response-surface"] {
+                    Section("Agent Response") {
+                        A2UISurfaceView(viewModel: vm, catalog: RizzCustomCatalog(), scrolls: false)
+                    }
+                }
+
+                Section("How it works") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        bulletPoint("1", "Client sends \"START_GALLERY\" to Agent")
+                        bulletPoint("2", "Agent returns A2UI messages (createSurface + updateComponents + updateDataModel for each component)")
+                        bulletPoint("3", "Client renders each Surface as a card")
+                        bulletPoint("4", "User interacts → action sent to Agent → Agent returns updateComponents for response-surface")
+                    }
+                }
+
+                Section("Agent") {
+                    LabeledContent("URL", value: agentURL.absoluteString)
+                    LabeledContent("Protocol", value: "A2A JSON-RPC")
+                    LabeledContent("AI Model", value: "None (hardcoded)")
+                    LabeledContent("Surfaces", value: "\(store.orderedSurfaceIds.count)")
+                }
+                .font(.caption)
+            }
+            .padding()
+        }
+    }
+
+    private func bulletPoint(_ label: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(label)
+                .font(.caption.bold())
+                .foregroundStyle(.tint)
+                .frame(minWidth: 20)
+            Text(text)
+                .font(.caption)
+        }
+    }
+
+    // MARK: - Action Log
+
+    private var actionLogView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Label("Action Log", systemImage: "list.bullet.rectangle")
+                    .font(.subheadline.bold())
+                Spacer()
+                if !actionLog.isEmpty {
+                    Button("Clear") { actionLog.removeAll() }
+                        .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            if actionLog.isEmpty {
+                Text("Interact with components to see actions here.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(actionLog) { entry in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Image(systemName: entry.direction == .outgoing
+                                  ? "arrow.up.circle.fill"
+                                  : "arrow.down.circle.fill")
+                            .foregroundStyle(entry.direction == .outgoing ? .blue : .green)
+                            Text(entry.summary).font(.subheadline).bold()
+                            Spacer()
+                            Text(entry.timestamp, style: .time)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        if !entry.detail.isEmpty {
+                            Text(entry.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(4)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Networking
+
+    private func connect() async {
+        status = .connecting
+        let a2aClient = A2AClient(endpointURL: agentURL)
+        client = a2aClient
+
+        do {
+            let result = try await a2aClient.sendText(initialQuery)
+            var errorCount = 0
+            for msg in result.messages {
+                do { try store.process(msg) } catch { errorCount += 1 }
+            }
+            logEntry(.incoming, summary: "Initial load", detail: "Received \(result.messages.count) message(s)" + (errorCount > 0 ? ", \(errorCount) skipped" : ""))
+            status = .connected
+        } catch {
+            status = .error(error.localizedDescription)
+        }
+    }
+
+    private func sendAction(_ action: ResolvedAction, surfaceId: String) async {
+        guard let client else { return }
+        do {
+            let result = try await client.sendAction(action, surfaceId: surfaceId)
+            for msg in result.messages {
+                try? store.process(msg)
+            }
+            if !result.messages.isEmpty {
+                logEntry(.incoming, summary: "Response to \(action.name)", detail: "Received \(result.messages.count) message(s)")
+            }
+        } catch {
+            logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Log Value (mirrors Lit demo's #logValue)
+
+    private func logDataValue(vm: SurfaceViewModel, path: String, item: DemoItem) {
+        let value = vm.makeDataContext().resolve(DynamicString.dataBinding(path: path))
+        logAction(
+            ResolvedAction(name: "shell_log_value", sourceComponentId: "log-btn", context: [
+                "path": .string(path),
+                "value": .string(value),
+                "component": .string(item.title),
+            ]),
+            surfaceId: item.id
+        )
+        Task { await sendLogValueAction(surfaceId: item.id, path: path, value: value, component: item.title) }
+    }
+
+    private func sendLogValueAction(surfaceId: String, path: String, value: String, component: String) async {
+        guard let client else { return }
+        let action = ResolvedAction(
+            name: "shell_log_value",
+            sourceComponentId: "shell-log-btn",
+            context: [
+                "path": .string(path),
+                "value": .string(value),
+                "component": .string(component),
+            ]
+        )
+        do {
+            let result = try await client.sendAction(action, surfaceId: surfaceId)
+            for msg in result.messages {
+                try? store.process(msg)
+            }
+            if !result.messages.isEmpty {
+                logEntry(.incoming, summary: "Response to log_value", detail: "Received \(result.messages.count) message(s)")
+            }
+        } catch {
+            logEntry(.incoming, summary: "Error", detail: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Logging Helpers
+
+    private func logAction(_ action: ResolvedAction, surfaceId: String) {
+        let contextStr = action.context.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        logEntry(.outgoing, summary: "\(action.name) [\(surfaceId)]", detail: contextStr)
+    }
+
+    private func logEntry(_ direction: ActionLogEntry.Direction, summary: String, detail: String) {
+        actionLog.append(ActionLogEntry(direction: direction, summary: summary, detail: detail))
+    }
+}
+
+// MARK: - Supporting Types
+
+private enum InspectorMode {
+    case info, log
+}
+
+private enum ConnectionStatus {
+    case idle, connecting, connected, error(String)
+
+    func subtitle(url: URL) -> String {
+        switch self {
+        case .idle: return url.absoluteString
+        case .connecting: return "Connecting to \(url.host() ?? url.absoluteString)…"
+        case .connected: return "Connected · \(url.absoluteString)"
+        case .error(let msg): return "Error: \(msg)"
+        }
+    }
+}
+
+private struct ActionLogEntry: Identifiable {
+    let id = UUID()
+    let direction: Direction
+    let summary: String
+    let detail: String
+    let timestamp = Date()
+
+    enum Direction { case outgoing, incoming }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/RizzchartsPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/RizzchartsPage.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+/// Static demo page for Rizzcharts custom components (Chart + Map).
+struct RizzchartsPage: View {
+    @State private var selectedTab = 0
+    @State private var chartStore = SurfaceStore()
+    @State private var mapStore = SurfaceStore()
+    @State private var loadError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("View", selection: $selectedTab) {
+                Text("Chart").tag(0)
+                Text("Map").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            Divider()
+
+            if let error = loadError {
+                ContentUnavailableView(
+                    "Load Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error)
+                )
+            } else {
+                ScrollView {
+                    surfaceContent(store: selectedTab == 0 ? chartStore : mapStore)
+                }
+            }
+        }
+        .navigationTitle("Rizzcharts")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { loadData() }
+    }
+
+    @ViewBuilder
+    private func surfaceContent(store: SurfaceStore) -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(store.orderedSurfaceIds, id: \.self) { surfaceId in
+                if let vm = store.viewModels[surfaceId] {
+                    A2UISurfaceView(viewModel: vm, catalog: RizzCustomCatalog(), scrolls: false)
+                        .padding()
+                }
+            }
+        }
+    }
+
+    private func loadData() {
+        loadBundle(filename: "rizzcharts_chart", into: chartStore)
+        loadBundle(filename: "rizzcharts_map", into: mapStore)
+    }
+
+    private func loadBundle(filename: String, into store: SurfaceStore) {
+        do {
+            let messages = try DemoMessages.load(filename)
+            store.process(messages)
+        } catch {
+            loadError = "Could not load \(filename).json"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RizzchartsPage()
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/SamplesPage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/SamplesPage.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+// MARK: - Data
+
+enum SampleDemo: String, CaseIterable, Identifiable {
+    case contactForm = "Contact Form"
+    case contactCard = "Contact Card"
+    case recipe = "Recipe"
+    case incrementalUpdate = "Incremental Update"
+    case actionContext = "Action Context"
+    case formatFunctions = "Format Functions"
+
+    var id: String { rawValue }
+
+    var filename: String {
+        switch self {
+        case .contactForm: return "contact_form"
+        case .contactCard: return "contact_card"
+        case .recipe: return "recipe"
+        case .incrementalUpdate: return "incremental_update"
+        case .actionContext: return "action_context"
+        case .formatFunctions: return "format_functions"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .contactForm: return "person.crop.rectangle"
+        case .contactCard: return "person.text.rectangle"
+        case .recipe: return "fork.knife"
+        case .incrementalUpdate: return "arrow.triangle.2.circlepath"
+        case .actionContext: return "arrow.up.message"
+        case .formatFunctions: return "calendar.badge.clock"
+        }
+    }
+}
+
+// MARK: - Detail Page
+
+struct SampleDetailPage: View {
+    let demo: SampleDemo
+
+    @State private var store = SurfaceStore()
+    @State private var loaded = false
+    @State private var errorText: String?
+
+    var body: some View {
+        Group {
+            if let errorText {
+                ContentUnavailableView(
+                    "Load Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(errorText)
+                )
+            } else if !loaded {
+                ProgressView()
+                    .task { loadJSON() }
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(store.orderedSurfaceIds, id: \.self) { surfaceId in
+                            if let vm = store.viewModels[surfaceId] {
+                                A2UISurfaceView(viewModel: vm, scrolls: false)
+                                    .padding()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(demo.rawValue)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    private func loadJSON() {
+        do {
+            let messages = try DemoMessages.load(demo.filename)
+            store.process(messages)
+            loaded = true
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SampleDetailPage(demo: .contactForm)
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Pages/StyleOverridePage.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Pages/StyleOverridePage.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+struct StyleOverridePage: View {
+    @State private var useCustom = true
+    @State private var showingInspector = false
+
+    private static let json = """
+    [
+      { "version": "v0.9", "createSurface": { "surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json" } },
+      { "version": "v0.9", "updateComponents": { "surfaceId": "main", "components": [
+        { "id": "root", "component": "Card", "child": "col" },
+        { "id": "col", "component": "Column", "children": ["title", "body", "row_icon", "btn"], "align": "stretch" },
+        { "id": "title", "component": "Text", "text": "Welcome", "variant": "h2" },
+        { "id": "body", "component": "Text", "text": "Toggle the switch to see how a custom A2UIStyle restyles A2UI components without changing the server JSON." },
+        { "id": "row_icon", "component": "Row", "children": ["ic", "ic_label"], "align": "center" },
+        { "id": "ic", "component": "Icon", "name": "home" },
+        { "id": "ic_label", "component": "Text", "text": "Home", "variant": "caption" },
+        { "id": "btn_t", "component": "Text", "text": "Primary Button" },
+        { "id": "btn", "component": "Button", "child": "btn_t", "variant": "primary", "action": { "event": { "name": "tap" } } }
+      ] } }
+    ]
+    """
+
+    /// A custom style built in code. Mirrors what the `.a2uiTextStyle` /
+    /// `.a2uiButtonStyle` / `.a2uiCardStyle` / `.a2uiIcon` view modifiers produce.
+    private static let customStyle = A2UIStyle(
+        primaryColor: .indigo,
+        textStyles: [
+            "h2": .init(font: .system(.title, design: .rounded), weight: .black, color: .indigo),
+            "caption": .init(color: .purple)
+        ],
+        iconOverrides: ["home": "house.fill"],
+        cardStyle: .init(cornerRadius: 20, shadowRadius: 8, backgroundColor: .indigo.opacity(0.05)),
+        buttonStyles: ["primary": .init(backgroundColor: .indigo, cornerRadius: 20)]
+    )
+
+    private static func makeViewModel() -> SurfaceViewModel {
+        let messages = (try? DemoMessages.decode(Data(json.utf8))) ?? []
+        return makeSurfaceViewModel(from: messages)
+    }
+
+    @State private var viewModel = makeViewModel()
+
+    var body: some View {
+        List {
+            Section {
+                Toggle("Custom Style", isOn: $useCustom.animation())
+            }
+
+            Section("Preview") {
+                A2UISurfaceView(viewModel: viewModel, scrolls: false)
+            }
+        }
+        .navigationTitle("Style Override")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingInspector.toggle()
+                } label: {
+                    Label("About", systemImage: "info.circle")
+                }
+            }
+        }
+#if !os(visionOS) && !os(tvOS)
+        .inspector(isPresented: $showingInspector) {
+            ScrollView {
+                Text("Shows how to restyle built-in A2UI components with a custom A2UIStyle (text variants, button variant, card, icon overrides) — no server-side JSON changes needed.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 400)
+        }
+#endif
+        .onAppear { applyStyle() }
+        .onChange(of: useCustom) { applyStyle() }
+    }
+
+    private func applyStyle() {
+        viewModel.a2uiStyle = useCustom ? Self.customStyle : A2UIStyle()
+    }
+}

--- a/samples/sample_0.9/A2UIDemoApp/Support/DemoSupport.swift
+++ b/samples/sample_0.9/A2UIDemoApp/Support/DemoSupport.swift
@@ -1,0 +1,224 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+// MARK: - Catalog
+
+/// The catalog used by every surface in this demo.
+///
+/// It reuses the v0.9 basic catalog (all standard components + functions such as
+/// `formatDate`) and adds the demo's custom Rizzcharts component type names so
+/// they pass catalog validation. The id matches the v0.9 spec basic catalog so
+/// JSON copied verbatim from `specification/v0_9/catalogs/basic/examples` works.
+let demoCatalogId = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+
+let demoCatalog = Catalog(
+    id: demoCatalogId,
+    componentNames: basicCatalog.componentNames.union(["Canvas", "Chart", "GoogleMap"]),
+    functions: basicCatalog.functions
+)
+
+// MARK: - Custom component catalog (Rizzcharts)
+
+/// Renders the demo's custom component types. Returning `EmptyView()` tells the
+/// framework to fall back to rendering the node's children (used for `Canvas`,
+/// which is a plain container).
+struct RizzCustomCatalog: CustomComponentCatalog {
+    @ViewBuilder
+    func build(typeName: String, node: ComponentNode, surface: SurfaceModel) -> some View {
+        switch typeName {
+        case "Chart":
+            RizzchartChartView(node: node, surface: surface)
+        case "GoogleMap":
+            RizzchartMapView(node: node, surface: surface)
+        default:
+            // "Canvas" and any unknown type: framework renders children in a VStack.
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - SurfaceStore
+
+/// Holds one `SurfaceViewModel` per surface id, in arrival order.
+///
+/// This is the v0.9 replacement for the v0.8 `SurfaceManager`. Each surface gets
+/// its own `SurfaceModel` (created with `demoCatalog`) and `SurfaceViewModel`, so
+/// `createSurface` / `updateComponents` / `updateDataModel` / `deleteSurface`
+/// messages are routed to the right surface by id.
+@Observable
+final class SurfaceStore {
+    let catalog: Catalog
+    private(set) var orderedSurfaceIds: [String] = []
+    private(set) var viewModels: [String: SurfaceViewModel] = [:]
+
+    init(catalog: Catalog = demoCatalog) {
+        self.catalog = catalog
+    }
+
+    func viewModel(for surfaceId: String) -> SurfaceViewModel? {
+        viewModels[surfaceId]
+    }
+
+    @discardableResult
+    func process(_ messages: [A2uiMessage]) -> [Error] {
+        var errors: [Error] = []
+        for message in messages {
+            do { try process(message) } catch { errors.append(error) }
+        }
+        return errors
+    }
+
+    func process(_ message: A2uiMessage) throws {
+        switch message {
+        case .createSurface(let payload):
+            let surface = SurfaceModel(
+                id: payload.surfaceId,
+                catalog: catalog,
+                theme: payload.theme,
+                sendDataModel: payload.sendDataModel
+            )
+            let vm = SurfaceViewModel(surface: surface)
+            viewModels[payload.surfaceId] = vm
+            if !orderedSurfaceIds.contains(payload.surfaceId) {
+                orderedSurfaceIds.append(payload.surfaceId)
+            }
+            try vm.processMessage(message)
+
+        case .updateComponents(let payload):
+            try viewModels[payload.surfaceId]?.processMessage(message)
+
+        case .updateDataModel(let payload):
+            try viewModels[payload.surfaceId]?.processMessage(message)
+
+        case .deleteSurface(let payload):
+            try viewModels[payload.surfaceId]?.processMessage(message)
+            viewModels[payload.surfaceId] = nil
+            orderedSurfaceIds.removeAll { $0 == payload.surfaceId }
+        }
+    }
+
+    func clearAll() {
+        viewModels.removeAll()
+        orderedSurfaceIds.removeAll()
+    }
+}
+
+// MARK: - Message loading helpers
+
+enum DemoMessages {
+    /// Decodes an array of v0.9 messages from raw JSON data.
+    /// Accepts either a top-level JSON array or newline-delimited JSON (JSONL).
+    static func decode(_ data: Data) throws -> [A2uiMessage] {
+        let decoder = JSONDecoder()
+        // Fast path: a single JSON array of messages.
+        if let messages = try? decoder.decode([A2uiMessage].self, from: data) {
+            return messages
+        }
+        // Fallback: JSONL — one message per non-empty line.
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
+        var messages: [A2uiMessage] = []
+        for line in text.components(separatedBy: "\n") where !line.trimmingCharacters(in: .whitespaces).isEmpty {
+            if let lineData = line.data(using: .utf8) {
+                messages.append(try decoder.decode(A2uiMessage.self, from: lineData))
+            }
+        }
+        return messages
+    }
+
+    /// Loads and decodes v0.9 messages from a bundled `.json` resource.
+    static func load(_ filename: String) throws -> [A2uiMessage] {
+        guard let url = Bundle.main.url(forResource: filename, withExtension: "json") else {
+            throw DemoError.missingResource(filename)
+        }
+        return try decode(Data(contentsOf: url))
+    }
+
+    /// First surface id referenced by a message batch (used for single-surface pages).
+    static func firstSurfaceId(_ messages: [A2uiMessage]) -> String? {
+        for message in messages {
+            switch message {
+            case .createSurface(let p): return p.surfaceId
+            case .updateComponents(let p): return p.surfaceId
+            case .updateDataModel(let p): return p.surfaceId
+            case .deleteSurface(let p): return p.surfaceId
+            }
+        }
+        return nil
+    }
+}
+
+enum DemoError: LocalizedError {
+    case missingResource(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingResource(let name): return "\(name).json not found in bundle"
+        }
+    }
+}
+
+/// Builds a single `SurfaceViewModel` from a message batch, creating its backing
+/// `SurfaceModel` with `demoCatalog` (so functions like `formatDate` resolve).
+func makeSurfaceViewModel(
+    from messages: [A2uiMessage],
+    catalog: Catalog = demoCatalog
+) -> SurfaceViewModel {
+    let create: CreateSurfacePayload? = messages.compactMap {
+        if case .createSurface(let p) = $0 { return p }
+        return nil
+    }.first
+    let surface = SurfaceModel(
+        id: create?.surfaceId ?? DemoMessages.firstSurfaceId(messages) ?? "main",
+        catalog: catalog,
+        theme: create?.theme,
+        sendDataModel: create?.sendDataModel ?? false
+    )
+    let vm = SurfaceViewModel(surface: surface)
+    vm.processMessages(messages)
+    return vm
+}
+
+// MARK: - Pretty JSON
+
+/// Re-serializes raw A2UI JSON (a JSON array or JSONL) into a pretty-printed
+/// string for the "JSON" inspector tabs.
+func prettyPrintedA2UIJSON(_ raw: String) -> String {
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+
+    if let data = raw.data(using: .utf8),
+       let value = try? decoder.decode(AnyCodable.self, from: data),
+       let pretty = try? encoder.encode(value),
+       let string = String(data: pretty, encoding: .utf8) {
+        return string
+    }
+    // JSONL fallback: pretty-print each line.
+    return raw
+        .components(separatedBy: "\n")
+        .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        .map { line -> String in
+            guard let data = line.data(using: .utf8),
+                  let value = try? decoder.decode(AnyCodable.self, from: data),
+                  let pretty = try? encoder.encode(value),
+                  let string = String(data: pretty, encoding: .utf8)
+            else { return line }
+            return string
+        }
+        .joined(separator: "\n\n")
+}

--- a/samples/sample_0.9/A2UIDemoApp/action_context.json
+++ b/samples/sample_0.9/A2UIDemoApp/action_context.json
@@ -1,0 +1,58 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "main",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["title", "desc", "name_field", "email_field", "divider", "submit_btn"],
+          "align": "stretch"
+        },
+        { "id": "title", "component": "Text", "text": "Quick Contact", "variant": "h3" },
+        {
+          "id": "desc",
+          "component": "Text",
+          "text": "Fill the form and tap Send. The resolved action context will appear below.",
+          "variant": "caption"
+        },
+        { "id": "name_field", "component": "TextField", "label": "Name", "value": { "path": "/name" } },
+        { "id": "email_field", "component": "TextField", "label": "Email", "value": { "path": "/email" } },
+        { "id": "divider", "component": "Divider" },
+        { "id": "submit_label", "component": "Text", "text": "Send" },
+        {
+          "id": "submit_btn",
+          "component": "Button",
+          "child": "submit_label",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "submitContact",
+              "context": {
+                "userName": { "path": "/name" },
+                "userEmail": { "path": "/email" },
+                "source": "demo_app"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "main",
+      "value": { "name": "Alice", "email": "alice@example.com" }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/contact_card.json
+++ b/samples/sample_0.9/A2UIDemoApp/contact_card.json
@@ -1,0 +1,194 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "gallery-contact-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "gallery-contact-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "main-column"
+        },
+        {
+          "id": "main-column",
+          "component": "Column",
+          "children": [
+            "avatar-image",
+            "name",
+            "title",
+            "divider",
+            "contact-info",
+            "actions"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "avatar-image",
+          "component": "Image",
+          "url": {
+            "path": "/avatar"
+          },
+          "fit": "cover",
+          "variant": "avatar"
+        },
+        {
+          "id": "name",
+          "component": "Text",
+          "text": {
+            "path": "/name"
+          },
+          "variant": "h2"
+        },
+        {
+          "id": "title",
+          "component": "Text",
+          "text": {
+            "path": "/title"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "divider",
+          "component": "Divider"
+        },
+        {
+          "id": "contact-info",
+          "component": "Column",
+          "children": [
+            "phone-row",
+            "email-row",
+            "location-row"
+          ]
+        },
+        {
+          "id": "phone-row",
+          "component": "Row",
+          "children": [
+            "phone-icon",
+            "phone-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "phone-icon",
+          "component": "Icon",
+          "name": "phone"
+        },
+        {
+          "id": "phone-text",
+          "component": "Text",
+          "text": {
+            "path": "/phone"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "email-row",
+          "component": "Row",
+          "children": [
+            "email-icon",
+            "email-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "email-icon",
+          "component": "Icon",
+          "name": "mail"
+        },
+        {
+          "id": "email-text",
+          "component": "Text",
+          "text": {
+            "path": "/email"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "location-row",
+          "component": "Row",
+          "children": [
+            "location-icon",
+            "location-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "location-icon",
+          "component": "Icon",
+          "name": "locationOn"
+        },
+        {
+          "id": "location-text",
+          "component": "Text",
+          "text": {
+            "path": "/location"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "actions",
+          "component": "Row",
+          "children": [
+            "call-btn",
+            "message-btn"
+          ]
+        },
+        {
+          "id": "call-btn-text",
+          "component": "Text",
+          "text": "Call"
+        },
+        {
+          "id": "call-btn",
+          "component": "Button",
+          "child": "call-btn-text",
+          "action": {
+            "event": {
+              "name": "call",
+              "context": {}
+            }
+          }
+        },
+        {
+          "id": "message-btn-text",
+          "component": "Text",
+          "text": "Message"
+        },
+        {
+          "id": "message-btn",
+          "component": "Button",
+          "child": "message-btn-text",
+          "action": {
+            "event": {
+              "name": "message",
+              "context": {}
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "gallery-contact-card",
+      "value": {
+        "avatar": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop",
+        "name": "David Park",
+        "title": "Engineering Manager",
+        "phone": "+1 (555) 234-5678",
+        "email": "david.park@company.com",
+        "location": "San Francisco, CA"
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/contact_form.json
+++ b/samples/sample_0.9/A2UIDemoApp/contact_form.json
@@ -1,0 +1,89 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "contact_form",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "contact_form",
+      "components": [
+        { "id": "root", "component": "Card", "child": "form_container" },
+        {
+          "id": "form_container",
+          "component": "Column",
+          "children": ["header_row", "name_row", "email_field", "phone_field", "pref_picker", "divider_1", "newsletter_checkbox", "submit_button"],
+          "align": "stretch"
+        },
+        { "id": "header_row", "component": "Row", "children": ["header_icon", "header_text"], "align": "center" },
+        { "id": "header_icon", "component": "Icon", "name": "mail" },
+        { "id": "header_text", "component": "Text", "text": "Contact Us", "variant": "h2" },
+        { "id": "name_row", "component": "Row", "children": ["first_name_field", "last_name_field"], "justify": "spaceBetween" },
+        { "id": "first_name_field", "weight": 1, "component": "TextField", "label": "First name", "value": { "path": "/firstName" } },
+        { "id": "last_name_field", "weight": 1, "component": "TextField", "label": "Last name", "value": { "path": "/lastName" } },
+        {
+          "id": "email_field",
+          "component": "TextField",
+          "label": "Email",
+          "value": { "path": "/email" },
+          "variant": "shortText",
+          "validationRegexp": "^[\\w.+-]+@[\\w-]+\\.[a-zA-Z]{2,}$"
+        },
+        { "id": "phone_field", "component": "TextField", "label": "Phone", "value": { "path": "/phone" }, "variant": "number" },
+        {
+          "id": "pref_picker",
+          "component": "ChoicePicker",
+          "label": "Preferred contact method",
+          "value": { "path": "/preference" },
+          "variant": "mutuallyExclusive",
+          "displayStyle": "chips",
+          "options": [
+            { "label": "Email", "value": "email" },
+            { "label": "Phone", "value": "phone" },
+            { "label": "SMS", "value": "sms" }
+          ]
+        },
+        { "id": "divider_1", "component": "Divider" },
+        { "id": "newsletter_checkbox", "component": "CheckBox", "label": "Subscribe to our newsletter", "value": { "path": "/newsletter" } },
+        { "id": "submit_label", "component": "Text", "text": "Submit" },
+        {
+          "id": "submit_button",
+          "component": "Button",
+          "child": "submit_label",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "submitForm",
+              "context": {
+                "firstName": { "path": "/firstName" },
+                "lastName": { "path": "/lastName" },
+                "email": { "path": "/email" },
+                "phone": { "path": "/phone" },
+                "preference": { "path": "/preference" },
+                "newsletter": { "path": "/newsletter" }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "contact_form",
+      "value": {
+        "firstName": "Alex",
+        "lastName": "Jordan",
+        "email": "alex.jordan@example.com",
+        "phone": "4151711080",
+        "preference": "email",
+        "newsletter": true
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/format_functions.json
+++ b/samples/sample_0.9/A2UIDemoApp/format_functions.json
@@ -1,0 +1,70 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "main",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["title", "desc", "date_field", "divider", "submit_btn"],
+          "align": "stretch"
+        },
+        { "id": "title", "component": "Text", "text": "Format Functions", "variant": "h3" },
+        {
+          "id": "desc",
+          "component": "Text",
+          "text": "Pick a date and tap Send. The resolved action carries both the raw ISO string and a formatted value produced by the formatDate function.",
+          "variant": "caption"
+        },
+        {
+          "id": "date_field",
+          "component": "DateTimeInput",
+          "label": "Event Date",
+          "value": { "path": "/eventDate" },
+          "enableDate": true,
+          "enableTime": true
+        },
+        { "id": "divider", "component": "Divider" },
+        { "id": "submit_label", "component": "Text", "text": "Send" },
+        {
+          "id": "submit_btn",
+          "component": "Button",
+          "child": "submit_label",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "sendEvent",
+              "context": {
+                "rawDate": { "path": "/eventDate" },
+                "formatted": {
+                  "call": "formatDate",
+                  "args": {
+                    "value": { "path": "/eventDate" },
+                    "format": "MMM d, yyyy h:mm a"
+                  },
+                  "returnType": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "main",
+      "value": { "eventDate": "2026-06-15T14:30:00" }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/incremental_update.json
+++ b/samples/sample_0.9/A2UIDemoApp/incremental_update.json
@@ -1,0 +1,68 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "main",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["title", "divider", "msg_a"],
+          "align": "stretch"
+        },
+        { "id": "title", "component": "Text", "text": "Bulletin Board", "variant": "h2" },
+        { "id": "divider", "component": "Divider" },
+        { "id": "msg_a", "component": "Card", "child": "msg_a_text" },
+        { "id": "msg_a_text", "component": "Text", "text": "Message A: Hello everyone!" }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["title", "divider", "msg_a", "msg_b", "msg_c"],
+          "align": "stretch"
+        },
+        { "id": "msg_b", "component": "Card", "child": "msg_b_text" },
+        { "id": "msg_b_text", "component": "Text", "text": "Message B: Nice to meet you!" },
+        { "id": "msg_c", "component": "Card", "child": "msg_c_text" },
+        { "id": "msg_c_text", "component": "Text", "text": "Message C: Welcome aboard!" }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        { "id": "msg_a_text", "component": "Text", "text": "Message A: [EDITED] Updated content!" }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "main",
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["title", "divider", "msg_a", "msg_c"],
+          "align": "stretch"
+        }
+      ]
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/recipe.json
+++ b/samples/sample_0.9/A2UIDemoApp/recipe.json
@@ -1,0 +1,237 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "gallery-recipe-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "gallery-recipe-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "tabs-container"
+        },
+        {
+          "id": "tabs-container",
+          "component": "Tabs",
+          "tabs": [
+            {
+              "title": "Overview",
+              "child": "overview-col"
+            },
+            {
+              "title": "Ingredients",
+              "child": "ingredients-list"
+            },
+            {
+              "title": "Instructions",
+              "child": "instructions-list"
+            }
+          ]
+        },
+        {
+          "id": "overview-col",
+          "component": "Column",
+          "children": [
+            "recipe-image",
+            "overview-content"
+          ]
+        },
+        {
+          "id": "recipe-image",
+          "component": "Image",
+          "url": {
+            "path": "/image"
+          },
+          "fit": "cover"
+        },
+        {
+          "id": "overview-content",
+          "component": "Column",
+          "children": [
+            "title",
+            "rating-row",
+            "times-row",
+            "servings"
+          ]
+        },
+        {
+          "id": "title",
+          "component": "Text",
+          "text": {
+            "path": "/title"
+          },
+          "variant": "h3"
+        },
+        {
+          "id": "rating-row",
+          "component": "Row",
+          "children": [
+            "star-icon",
+            "rating",
+            "review-count"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "star-icon",
+          "component": "Icon",
+          "name": "star"
+        },
+        {
+          "id": "rating",
+          "component": "Text",
+          "text": {
+            "path": "/rating"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "review-count",
+          "component": "Text",
+          "text": {
+            "call": "formatString",
+            "args": {
+              "value": "(${formatNumber(value: ${/reviewCount})} ${pluralize(value: ${/reviewCount}, one: 'review', other: 'reviews')})"
+            },
+            "returnType": "string"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "times-row",
+          "component": "Row",
+          "children": [
+            "prep-time",
+            "cook-time"
+          ]
+        },
+        {
+          "id": "prep-time",
+          "component": "Row",
+          "children": [
+            "prep-icon",
+            "prep-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "prep-icon",
+          "component": "Icon",
+          "name": "calendarToday"
+        },
+        {
+          "id": "prep-text",
+          "component": "Text",
+          "text": {
+            "path": "/prepTime"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "cook-time",
+          "component": "Row",
+          "children": [
+            "cook-icon",
+            "cook-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "cook-icon",
+          "component": "Icon",
+          "name": "warning"
+        },
+        {
+          "id": "cook-text",
+          "component": "Text",
+          "text": {
+            "path": "/cookTime"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "servings",
+          "component": "Text",
+          "text": {
+            "path": "/servings"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "ingredients-list",
+          "component": "Column",
+          "children": {
+            "path": "/ingredients",
+            "componentId": "item-template"
+          }
+        },
+        {
+          "id": "instructions-list",
+          "component": "Column",
+          "children": {
+            "path": "/instructions",
+            "componentId": "item-template"
+          }
+        },
+        {
+          "id": "item-template",
+          "component": "Text",
+          "text": {
+            "path": "text"
+          },
+          "variant": "body"
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "gallery-recipe-card",
+      "value": {
+        "image": "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=300&h=180&fit=crop",
+        "title": "Mediterranean Quinoa Bowl",
+        "rating": "4.9",
+        "reviewCount": 1247,
+        "prepTime": "15 min prep",
+        "cookTime": "20 min cook",
+        "servings": "Serves 4",
+        "ingredients": [
+          {
+            "text": "1 cup quinoa"
+          },
+          {
+            "text": "2 cups water"
+          },
+          {
+            "text": "1 cucumber, diced"
+          },
+          {
+            "text": "1 cup cherry tomatoes, halved"
+          }
+        ],
+        "instructions": [
+          {
+            "text": "1. Rinse quinoa and bring to a boil in water."
+          },
+          {
+            "text": "2. Reduce heat and simmer for 15 minutes."
+          },
+          {
+            "text": "3. Fluff with a fork and let cool."
+          },
+          {
+            "text": "4. Mix with diced vegetables."
+          }
+        ]
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/restaurant_list.json
+++ b/samples/sample_0.9/A2UIDemoApp/restaurant_list.json
@@ -1,0 +1,74 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "default",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "theme": { "primaryColor": "#FF5722" },
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "default",
+      "components": [
+        { "id": "root", "component": "Column", "children": ["title-heading", "item-list"], "align": "stretch" },
+        { "id": "title-heading", "component": "Text", "variant": "h1", "text": { "path": "/title" } },
+        { "id": "item-list", "component": "List", "direction": "vertical", "children": { "componentId": "item-card-template", "path": "/items" } },
+        { "id": "item-card-template", "component": "Card", "child": "card-layout" },
+        { "id": "card-layout", "component": "Row", "children": ["template-image", "card-details"] },
+        { "id": "template-image", "weight": 1, "component": "Image", "url": { "path": "imageUrl" }, "variant": "smallFeature", "fit": "cover" },
+        { "id": "card-details", "weight": 2, "component": "Column", "children": ["template-name", "template-rating", "template-detail", "template-book-button"] },
+        { "id": "template-name", "component": "Text", "variant": "h3", "text": { "path": "name" } },
+        { "id": "template-rating", "component": "Text", "variant": "h5", "text": { "path": "rating" } },
+        { "id": "template-detail", "component": "Text", "text": { "path": "detail" } },
+        { "id": "book-now-text", "component": "Text", "text": "Book Now" },
+        {
+          "id": "template-book-button",
+          "component": "Button",
+          "child": "book-now-text",
+          "variant": "primary",
+          "action": {
+            "event": {
+              "name": "book_restaurant",
+              "context": { "restaurantName": { "path": "name" }, "address": { "path": "address" } }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "default",
+      "value": {
+        "title": "Nearby Restaurants",
+        "items": [
+          {
+            "name": "Xi'an Famous Foods",
+            "rating": "★★★★☆  4.8",
+            "detail": "Spicy hand-pulled noodles and lamb burgers",
+            "imageUrl": "https://images.unsplash.com/photo-1555126634-323283e090fa?w=200&h=200&fit=crop",
+            "address": "81 St Marks Pl, New York"
+          },
+          {
+            "name": "Le Bernardin",
+            "rating": "★★★★★  4.9",
+            "detail": "World-class French seafood dining",
+            "imageUrl": "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=200&h=200&fit=crop",
+            "address": "155 W 51st St, New York"
+          },
+          {
+            "name": "Joe's Pizza",
+            "rating": "★★★★☆  4.6",
+            "detail": "Classic New York slices since 1975",
+            "imageUrl": "https://images.unsplash.com/photo-1513104890138-7c749659a591?w=200&h=200&fit=crop",
+            "address": "7 Carmine St, New York"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/rizzcharts_chart.json
+++ b/samples/sample_0.9/A2UIDemoApp/rizzcharts_chart.json
@@ -1,0 +1,71 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "sales-dashboard",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "sales-dashboard",
+      "components": [
+        { "id": "root", "component": "Canvas", "children": ["chart-container"] },
+        { "id": "chart-container", "component": "Column", "children": ["sales-chart"], "align": "center" },
+        {
+          "id": "sales-chart",
+          "component": "Chart",
+          "type": "doughnut",
+          "title": { "path": "/chart/title" },
+          "chartData": { "path": "/chart/items" }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "sales-dashboard",
+      "value": {
+        "chart": {
+          "title": "Sales by Category",
+          "items": [
+            {
+              "label": "Apparel",
+              "value": 41,
+              "drillDown": [
+                { "label": "Tops", "value": 31 },
+                { "label": "Bottoms", "value": 38 },
+                { "label": "Outerwear", "value": 20 },
+                { "label": "Footwear", "value": 11 }
+              ]
+            },
+            {
+              "label": "Home Goods",
+              "value": 15,
+              "drillDown": [
+                { "label": "Pillow", "value": 8 },
+                { "label": "Coffee Maker", "value": 16 },
+                { "label": "Area Rug", "value": 3 },
+                { "label": "Bath Towels", "value": 14 }
+              ]
+            },
+            {
+              "label": "Electronics",
+              "value": 28,
+              "drillDown": [
+                { "label": "Phones", "value": 25 },
+                { "label": "Laptops", "value": 27 },
+                { "label": "TVs", "value": 21 },
+                { "label": "Other", "value": 27 }
+              ]
+            },
+            { "label": "Health & Beauty", "value": 10 },
+            { "label": "Other", "value": 6 }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoApp/rizzcharts_map.json
+++ b/samples/sample_0.9/A2UIDemoApp/rizzcharts_map.json
@@ -1,0 +1,47 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "la-map-view",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "la-map-view",
+      "components": [
+        { "id": "root", "component": "Canvas", "children": ["map-layout-container"] },
+        { "id": "map-layout-container", "component": "Column", "children": ["map-header", "location-map"], "align": "stretch" },
+        { "id": "map-header", "component": "Text", "text": "Points of Interest in Los Angeles", "variant": "h2" },
+        {
+          "id": "location-map",
+          "component": "GoogleMap",
+          "center": { "path": "/mapConfig/center" },
+          "zoom": { "path": "/mapConfig/zoom" },
+          "pins": { "path": "/mapConfig/locations" }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "la-map-view",
+      "value": {
+        "mapConfig": {
+          "center": { "lat": 34.0522, "lng": -118.2437 },
+          "zoom": 11,
+          "locations": [
+            { "lat": 34.0135, "lng": -118.4947, "name": "Google Store Santa Monica", "description": "Your local destination for Google hardware." },
+            { "lat": 34.1341, "lng": -118.3215, "name": "Griffith Observatory" },
+            { "lat": 34.1340, "lng": -118.3397, "name": "Hollywood Sign Viewpoint" },
+            { "lat": 34.0453, "lng": -118.2673, "name": "Crypto.com Arena" },
+            { "lat": 34.0639, "lng": -118.3592, "name": "LACMA" },
+            { "lat": 33.9850, "lng": -118.4729, "name": "Venice Beach Boardwalk" }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoWatchApp/A2UIDemoWatchApp.swift
+++ b/samples/sample_0.9/A2UIDemoWatchApp/A2UIDemoWatchApp.swift
@@ -1,0 +1,17 @@
+//
+//  A2UIDemoWatchAppApp.swift
+//  A2UIDemoWatchApp Watch App
+//
+//  Created by hong on 2/27/26.
+//
+
+import SwiftUI
+
+@main
+struct A2UIDemoWatchApp_Watch_AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/Contents.json
+++ b/samples/sample_0.9/A2UIDemoWatchApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/sample_0.9/A2UIDemoWatchApp/ContentView.swift
+++ b/samples/sample_0.9/A2UIDemoWatchApp/ContentView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import A2UISwiftCore
+import A2UISwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Contact Card") {
+                    SampleView(filename: "contact_card")
+                        .navigationTitle("Contact Card")
+                }
+                NavigationLink("Recipe") {
+                    SampleView(filename: "recipe")
+                        .navigationTitle("Recipe")
+                }
+            }
+            .navigationTitle("A2UI Watch")
+        }
+    }
+}
+
+struct SampleView: View {
+    let filename: String
+
+    @State private var viewModel: SurfaceViewModel?
+    @State private var errorText: String?
+
+    var body: some View {
+        Group {
+            if let errorText {
+                Text(errorText)
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            } else if let viewModel {
+                A2UISurfaceView(viewModel: viewModel)
+            } else {
+                ProgressView()
+                    .task { loadJSON() }
+            }
+        }
+    }
+
+    private func loadJSON() {
+        guard let url = Bundle.main.url(forResource: filename, withExtension: "json") else {
+            errorText = "\(filename).json not found"
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let messages = try JSONDecoder().decode([A2uiMessage].self, from: data)
+            let surfaceId = messages.compactMap { message -> String? in
+                if case .createSurface(let p) = message { return p.surfaceId }
+                return nil
+            }.first ?? "main"
+            let surface = SurfaceModel(id: surfaceId, catalog: basicCatalog)
+            let vm = SurfaceViewModel(surface: surface)
+            vm.processMessages(messages)
+            viewModel = vm
+        } catch {
+            errorText = error.localizedDescription
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/samples/sample_0.9/A2UIDemoWatchApp/contact_card.json
+++ b/samples/sample_0.9/A2UIDemoWatchApp/contact_card.json
@@ -1,0 +1,194 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "gallery-contact-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "gallery-contact-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "main-column"
+        },
+        {
+          "id": "main-column",
+          "component": "Column",
+          "children": [
+            "avatar-image",
+            "name",
+            "title",
+            "divider",
+            "contact-info",
+            "actions"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "avatar-image",
+          "component": "Image",
+          "url": {
+            "path": "/avatar"
+          },
+          "fit": "cover",
+          "variant": "avatar"
+        },
+        {
+          "id": "name",
+          "component": "Text",
+          "text": {
+            "path": "/name"
+          },
+          "variant": "h2"
+        },
+        {
+          "id": "title",
+          "component": "Text",
+          "text": {
+            "path": "/title"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "divider",
+          "component": "Divider"
+        },
+        {
+          "id": "contact-info",
+          "component": "Column",
+          "children": [
+            "phone-row",
+            "email-row",
+            "location-row"
+          ]
+        },
+        {
+          "id": "phone-row",
+          "component": "Row",
+          "children": [
+            "phone-icon",
+            "phone-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "phone-icon",
+          "component": "Icon",
+          "name": "phone"
+        },
+        {
+          "id": "phone-text",
+          "component": "Text",
+          "text": {
+            "path": "/phone"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "email-row",
+          "component": "Row",
+          "children": [
+            "email-icon",
+            "email-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "email-icon",
+          "component": "Icon",
+          "name": "mail"
+        },
+        {
+          "id": "email-text",
+          "component": "Text",
+          "text": {
+            "path": "/email"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "location-row",
+          "component": "Row",
+          "children": [
+            "location-icon",
+            "location-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "location-icon",
+          "component": "Icon",
+          "name": "locationOn"
+        },
+        {
+          "id": "location-text",
+          "component": "Text",
+          "text": {
+            "path": "/location"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "actions",
+          "component": "Row",
+          "children": [
+            "call-btn",
+            "message-btn"
+          ]
+        },
+        {
+          "id": "call-btn-text",
+          "component": "Text",
+          "text": "Call"
+        },
+        {
+          "id": "call-btn",
+          "component": "Button",
+          "child": "call-btn-text",
+          "action": {
+            "event": {
+              "name": "call",
+              "context": {}
+            }
+          }
+        },
+        {
+          "id": "message-btn-text",
+          "component": "Text",
+          "text": "Message"
+        },
+        {
+          "id": "message-btn",
+          "component": "Button",
+          "child": "message-btn-text",
+          "action": {
+            "event": {
+              "name": "message",
+              "context": {}
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "gallery-contact-card",
+      "value": {
+        "avatar": "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop",
+        "name": "David Park",
+        "title": "Engineering Manager",
+        "phone": "+1 (555) 234-5678",
+        "email": "david.park@company.com",
+        "location": "San Francisco, CA"
+      }
+    }
+  }
+]

--- a/samples/sample_0.9/A2UIDemoWatchApp/recipe.json
+++ b/samples/sample_0.9/A2UIDemoWatchApp/recipe.json
@@ -1,0 +1,237 @@
+[
+  {
+    "version": "v0.9",
+    "createSurface": {
+      "surfaceId": "gallery-recipe-card",
+      "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+      "sendDataModel": true
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateComponents": {
+      "surfaceId": "gallery-recipe-card",
+      "components": [
+        {
+          "id": "root",
+          "component": "Card",
+          "child": "tabs-container"
+        },
+        {
+          "id": "tabs-container",
+          "component": "Tabs",
+          "tabs": [
+            {
+              "title": "Overview",
+              "child": "overview-col"
+            },
+            {
+              "title": "Ingredients",
+              "child": "ingredients-list"
+            },
+            {
+              "title": "Instructions",
+              "child": "instructions-list"
+            }
+          ]
+        },
+        {
+          "id": "overview-col",
+          "component": "Column",
+          "children": [
+            "recipe-image",
+            "overview-content"
+          ]
+        },
+        {
+          "id": "recipe-image",
+          "component": "Image",
+          "url": {
+            "path": "/image"
+          },
+          "fit": "cover"
+        },
+        {
+          "id": "overview-content",
+          "component": "Column",
+          "children": [
+            "title",
+            "rating-row",
+            "times-row",
+            "servings"
+          ]
+        },
+        {
+          "id": "title",
+          "component": "Text",
+          "text": {
+            "path": "/title"
+          },
+          "variant": "h3"
+        },
+        {
+          "id": "rating-row",
+          "component": "Row",
+          "children": [
+            "star-icon",
+            "rating",
+            "review-count"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "star-icon",
+          "component": "Icon",
+          "name": "star"
+        },
+        {
+          "id": "rating",
+          "component": "Text",
+          "text": {
+            "path": "/rating"
+          },
+          "variant": "body"
+        },
+        {
+          "id": "review-count",
+          "component": "Text",
+          "text": {
+            "call": "formatString",
+            "args": {
+              "value": "(${formatNumber(value: ${/reviewCount})} ${pluralize(value: ${/reviewCount}, one: 'review', other: 'reviews')})"
+            },
+            "returnType": "string"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "times-row",
+          "component": "Row",
+          "children": [
+            "prep-time",
+            "cook-time"
+          ]
+        },
+        {
+          "id": "prep-time",
+          "component": "Row",
+          "children": [
+            "prep-icon",
+            "prep-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "prep-icon",
+          "component": "Icon",
+          "name": "calendarToday"
+        },
+        {
+          "id": "prep-text",
+          "component": "Text",
+          "text": {
+            "path": "/prepTime"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "cook-time",
+          "component": "Row",
+          "children": [
+            "cook-icon",
+            "cook-text"
+          ],
+          "align": "center"
+        },
+        {
+          "id": "cook-icon",
+          "component": "Icon",
+          "name": "warning"
+        },
+        {
+          "id": "cook-text",
+          "component": "Text",
+          "text": {
+            "path": "/cookTime"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "servings",
+          "component": "Text",
+          "text": {
+            "path": "/servings"
+          },
+          "variant": "caption"
+        },
+        {
+          "id": "ingredients-list",
+          "component": "Column",
+          "children": {
+            "path": "/ingredients",
+            "componentId": "item-template"
+          }
+        },
+        {
+          "id": "instructions-list",
+          "component": "Column",
+          "children": {
+            "path": "/instructions",
+            "componentId": "item-template"
+          }
+        },
+        {
+          "id": "item-template",
+          "component": "Text",
+          "text": {
+            "path": "text"
+          },
+          "variant": "body"
+        }
+      ]
+    }
+  },
+  {
+    "version": "v0.9",
+    "updateDataModel": {
+      "surfaceId": "gallery-recipe-card",
+      "value": {
+        "image": "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=300&h=180&fit=crop",
+        "title": "Mediterranean Quinoa Bowl",
+        "rating": "4.9",
+        "reviewCount": 1247,
+        "prepTime": "15 min prep",
+        "cookTime": "20 min cook",
+        "servings": "Serves 4",
+        "ingredients": [
+          {
+            "text": "1 cup quinoa"
+          },
+          {
+            "text": "2 cups water"
+          },
+          {
+            "text": "1 cucumber, diced"
+          },
+          {
+            "text": "1 cup cherry tomatoes, halved"
+          }
+        ],
+        "instructions": [
+          {
+            "text": "1. Rinse quinoa and bring to a boil in water."
+          },
+          {
+            "text": "2. Reduce heat and simmer for 15 minutes."
+          },
+          {
+            "text": "3. Fluff with a fork and let cool."
+          },
+          {
+            "text": "4. Mix with diced vegetables."
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
Ports the `A2UIDemoApp` + watch sample to the **A2UI v0.9** protocol stack (`A2UISwiftCore` + `A2UISwiftUI`), replacing the v0.8 (`v_08`) implementation. `sample_0.9` started as a copy of `sample_0.8`; this PR makes it a working v0.9 demo.

### Sample changes (`samples/sample_0.9`)
- All sample JSON converted to the **v0.9 wire format** (`createSurface` / `updateComponents` / `updateDataModel`, flat components, `{path}` bindings, `{event}` actions, `{componentId,path}` child templates, nested data), sourced from the official v0.9 spec examples where available.
- Every page/component + watch app rewritten onto `A2UISurfaceView` / `SurfaceViewModel`, a `SurfaceStore` (v0.9 replacement for the v0.8 `SurfaceManager`), a `RizzCustomCatalog` (`CustomComponentCatalog`), and a v0.9 `A2AClient` that decodes `[A2uiMessage]`.
- Both Xcode targets now link the v0.9 package products.

### Library fixes required by the port
- **feat(A2UISwiftUI):** add `scrolls` param to `A2UISurfaceView` so a surface can render embedded (lists/galleries/multi-surface) without nested-scroll collapse (the bare component view is internal).
- **fix(A2UISwiftUI):** rebuild the component tree on `updateDataModel` so data-driven list templates re-expand when data arrives after components (spec ordering). The in-place diff keeps static-data updates cheap. *(Fixes blank Recipe Ingredients/Instructions tabs.)*
- **fix(A2UISwiftCore):** guard `openUrl`'s `UIApplication` with `!os(watchOS)` (UIKit imports on watchOS but `UIApplication` is unavailable), unblocking the watchOS build.

## Test plan
- ✅ iOS app builds (`xcodebuild` iphonesimulator)
- ✅ watchOS app builds (watchsimulator)
- ✅ `A2UISwiftUITests` — 100 tests pass, incl. a new test asserting list templates re-expand when data arrives after components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)