### PR TITLE
Spec catch-up: v0.9 → v0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%20%7C%20macOS%20%7C%20tvOS%20%7C%20watchOS%20%7C%20visionOS-007AFF?logo=apple)](#requirements)
 [![SPM](https://img.shields.io/badge/SwiftPM-compatible-brightgreen)](#installation)
 [![Documentation](https://img.shields.io/badge/DocC-documentation-blue?logo=swift&logoColor=white)](https://bbc6bae9.github.io/a2ui-swift/documentation/)
-[![A2UI Spec](https://img.shields.io/badge/A2UI%20spec-v0.9-8A2BE2)](https://github.com/google/A2UI)
+[![A2UI Spec](https://img.shields.io/badge/A2UI%20spec-v0.9-8A2BE2)](https://github.com/a2ui-project/a2ui)
 [![License](https://img.shields.io/github/license/BBC6BAE9/a2ui-swift)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/BBC6BAE9/a2ui-swift?style=social)](https://github.com/BBC6BAE9/a2ui-swift/stargazers)
 
 </div>
 
-[A2UI](https://github.com/google/A2UI) is an open protocol from Google that lets AI agents generate rich, interactive user interfaces through declarative JSON — not executable code. The agent describes **what** to render; the renderer decides **how**, using real native platform controls.
+[A2UI](https://github.com/a2ui-project/a2ui) is an open protocol from Google that lets AI agents generate rich, interactive user interfaces through declarative JSON — not executable code. The agent describes **what** to render; the renderer decides **how**, using real native platform controls.
 
 **A2UI-Swift** is the Swift renderer for the entire Apple ecosystem, listed on the [official A2UI ecosystem page](https://a2ui.org/ecosystem/renderers/).
 
@@ -137,5 +137,5 @@ Issues and pull requests are welcome — whether it's a new catalog component, a
 [MIT](LICENSE)
 
 <div align="center">
-<sub>Built for the <a href="https://github.com/google/A2UI">A2UI</a> ecosystem · Swift on every Apple platform</sub>
+<sub>Built for the <a href="https://github.com/a2ui-project/a2ui">A2UI</a> ecosystem · Swift on every Apple platform</sub>
 </div>

--- a/Sources/A2UISwiftCore/Schema/ServerToClient.swift
+++ b/Sources/A2UISwiftCore/Schema/ServerToClient.swift
@@ -41,11 +41,12 @@ public enum A2uiMessage: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let version = try container.decode(String.self, forKey: .version)
-        guard version == "v0.9" else {
+        // v0.9.1 is a backward-compatible refinement of v0.9; schemas accept both.
+        guard version == "v0.9" || version == "v0.9.1" else {
             throw DecodingError.dataCorruptedError(
                 forKey: .version,
                 in: container,
-                debugDescription: #"A2UI message version must be "v0.9"."#
+                debugDescription: #"A2UI message version must be "v0.9" or "v0.9.1"."#
             )
         }
 

--- a/Sources/v_08/Networking/A2AClient.swift
+++ b/Sources/v_08/Networking/A2AClient.swift
@@ -41,7 +41,13 @@ public final class A2AClient: Sendable {
     private let session: URLSession
 
     private static let extensionHeader = "https://a2ui.org/a2a-extension/a2ui/v0.8"
+    // Outgoing parts use the v0.8 media type. The official SDKs select the send
+    // MIME by version — v0.8/v0.9 emit the legacy type, only v0.9.1+ emit the
+    // canonical one — and this client implements the v0.8 A2A extension.
     private static let a2uiMimeType = "application/json+a2ui"
+    // Canonical IANA media type (v0.9.1+). Accepted on receive for forward
+    // compatibility (mirrors the official SDKs accepting both on receive).
+    private static let canonicalA2uiMimeType = "application/a2ui+json"
     private static let standardCatalogId = "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
 
     /// Create a client that sends directly to `endpointURL`.
@@ -454,7 +460,7 @@ public final class A2AClient: Sendable {
             guard let kind = part["kind"] as? String, kind == "data",
                   let metadata = part["metadata"] as? [String: Any],
                   let mimeType = metadata["mimeType"] as? String,
-                  mimeType == Self.a2uiMimeType,
+                  mimeType == Self.a2uiMimeType || mimeType == Self.canonicalA2uiMimeType,
                   let payload = part["data"] else {
                 continue
             }

--- a/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
+++ b/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
@@ -402,4 +402,55 @@ struct MessageProcessorTests {
     // getClientCapabilities 生成 JSON Schema（基于 Zod schema、REF: 语法转换等），
     // 这是 TypeScript 服务端专属能力，用于向 LLM 描述可用组件结构。
     // Swift 实现作为纯客户端渲染器，不负责生成 capabilities，无对应实现。
+
+    // MARK: Version compatibility (v0.9 / v0.9.1)
+    // v0.9.1 is a backward-compatible refinement of v0.9; schemas accept both
+    // version strings. See specification/v0_9_1/docs/evolution_guide.md.
+
+    @Test("accepts v0.9 version string")
+    func acceptsV09Version() throws {
+        let json = #"{"version":"v0.9","deleteSurface":{"surfaceId":"s1"}}"#
+        let msg = try JSONDecoder().decode(A2uiMessage.self, from: json.data(using: .utf8)!)
+        if case .deleteSurface(let payload) = msg {
+            #expect(payload.surfaceId == "s1")
+        } else {
+            Issue.record("expected deleteSurface message")
+        }
+    }
+
+    @Test("accepts v0.9.1 version string")
+    func acceptsV091Version() throws {
+        let json = #"{"version":"v0.9.1","deleteSurface":{"surfaceId":"s1"}}"#
+        let msg = try JSONDecoder().decode(A2uiMessage.self, from: json.data(using: .utf8)!)
+        if case .deleteSurface(let payload) = msg {
+            #expect(payload.surfaceId == "s1")
+        } else {
+            Issue.record("expected deleteSurface message")
+        }
+    }
+
+    @Test("rejects unsupported version string")
+    func rejectsUnsupportedVersion() {
+        let json = #"{"version":"v0.8","deleteSurface":{"surfaceId":"s1"}}"#
+        #expect(throws: Error.self) {
+            let _ = try JSONDecoder().decode(A2uiMessage.self, from: json.data(using: .utf8)!)
+        }
+    }
+
+    // MARK: surfaceId uniqueness relaxation (v0.9.1)
+    // The lifetime-global uniqueness constraint was removed: a surfaceId may be
+    // reused once its surface is deleted. Re-creating a *live* surface is still
+    // an error. See specification/v0_9_1/docs/evolution_guide.md §2.2.
+
+    @Test("allows reusing a surfaceId after the surface is deleted")
+    func reusesSurfaceIdAfterDelete() {
+        let processor = makeProcessor()
+        processor.processMessages([createSurfaceMsg(surfaceId: "s1")])
+        processor.processMessages([.deleteSurface(DeleteSurfacePayload(surfaceId: "s1"))])
+        #expect(processor.model.getSurface("s1") == nil)
+
+        let errors = processor.processMessages([createSurfaceMsg(surfaceId: "s1")])
+        #expect(errors.isEmpty)
+        #expect(processor.model.getSurface("s1") != nil)
+    }
 }


### PR DESCRIPTION
Brings the renderer in line with **v0.9.1** (current production release), a backward-compatible refinement of v0.9. Closes #57.

## Changes
- **Version** — `ServerToClient` now accepts both `"v0.9"` and `"v0.9.1"` on decode (encoding still emits `"v0.9"`). This was the only version guard in the codebase.
- **MIME type** — the v0.8 `A2AClient` now accepts both `application/json+a2ui` (legacy) and `application/a2ui+json` (canonical) on receive, so payloads from modern agents aren't silently dropped. Outgoing parts keep the legacy v0.8 type, matching the official Python/Kotlin SDKs' version-conditional send logic (`create_a2ui_part`: v0.8/v0.9 emit legacy; only v0.9.1+ emit canonical).
- **surfaceId** — verified reuse-after-delete already works (delete removes the surface from the model); re-creating a live surface still errors. Added regression tests; no behavior change.
- **README** — updated `google/A2UI` links to `a2ui-project/a2ui` (repo was migrated).

## Tests
Added v0.9 / v0.9.1 version-acceptance, unsupported-version rejection, and surfaceId-reuse coverage. Full suite green (v_08: 87, MessageProcessor: 25).

References: [v0.9.1 evolution guide](https://github.com/a2ui-project/a2ui/blob/main/specification/v0_9_1/docs/evolution_guide.md) · official SDK MIME logic ([Python](https://github.com/a2ui-project/a2ui/blob/main/agent_sdks/python/a2ui_agent/src/a2ui/a2a/parts.py), [Kotlin](https://github.com/a2ui-project/a2ui/blob/main/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/a2a/A2uiA2a.kt))

🤖 Generated with [Claude Code](https://claude.com/claude-code)