### PR TITLE
Fix tvOS build: narrow iOS-only AVKit setters in SharedPlayerController

### DIFF
--- a/Sources/A2UISwiftUI/Helpers/SharedViewHelpers.swift
+++ b/Sources/A2UISwiftUI/Helpers/SharedViewHelpers.swift
@@ -192,9 +192,13 @@ final class SharedPlayerController {
     #if os(iOS) || os(tvOS) || os(visionOS)
     let playerViewController: AVPlayerViewController = {
         let vc = AVPlayerViewController()
+        // Gate each setter to the platforms that declare it: both are unavailable on
+        // tvOS, and allowsVideoFrameAnalysis is also unavailable on visionOS.
+        #if os(iOS) || os(visionOS)
         vc.entersFullScreenWhenPlaybackBegins = false
-        #if os(iOS) || os(tvOS)
-        if #available(iOS 16.0, tvOS 16.0, visionOS 1.0, *) {
+        #endif
+        #if os(iOS)
+        if #available(iOS 16.0, *) {
             vc.allowsVideoFrameAnalysis = false
         }
         #endif


### PR DESCRIPTION
## Problem

`A2UISwiftUI` declares `.tvOS` support, but `SharedPlayerController` (in `Helpers/SharedViewHelpers.swift`) configures its `AVPlayerViewController` with two AVKit setters that have **different** platform availability, both referenced inside the `#if os(iOS) || os(tvOS) || os(visionOS)` block:

- `entersFullScreenWhenPlaybackBegins`
- `allowsVideoFrameAnalysis` (under an inner `#if os(iOS) || os(tvOS)`)

Neither exists on tvOS, so **`A2UISwiftUI` fails to compile for tvOS**:

```
value of type 'AVPlayerViewController' has no member 'entersFullScreenWhenPlaybackBegins'
value of type 'AVPlayerViewController' has no member 'allowsVideoFrameAnalysis'
```

## Fix

The two setters don't share availability, so they get separate guards. Verified by compiling each against the individual SDKs:

| property | iOS | tvOS | visionOS |
|---|---|---|---|
| `entersFullScreenWhenPlaybackBegins` | ✅ | ❌ | ✅ |
| `allowsVideoFrameAnalysis` | ✅ | ❌ | ❌ |

So:
- `entersFullScreenWhenPlaybackBegins` → `#if os(iOS) || os(visionOS)`
- `allowsVideoFrameAnalysis` → `#if os(iOS)`

No behavior change on iOS/macOS/visionOS; it only stops referencing APIs on platforms that don't declare them.

## Verification

- `swift build` passes on macOS; the guarded construct typechecks against the iOS, tvOS, visionOS, and macOS SDKs.
- A downstream app rendering via `A2UISwiftUI` builds for tvOS (`xcodebuild … -destination 'generic/platform=tvOS Simulator'` → `BUILD SUCCEEDED`); iOS/macOS stay green.
