### PR TITLE
fix: dateTimeInput defaults

### DIFF
--- a/Sources/A2UIPlatform/Components/A2UIDateTimeInput.swift
+++ b/Sources/A2UIPlatform/Components/A2UIDateTimeInput.swift
@@ -54,7 +54,13 @@ final class A2UIDateTimeInput: PlatformView, A2UIPlatformComponent {
         let ctx = DataContext(surface: surface, path: node.dataContextPath)
         dataContext = ctx
         valueBindingPath = a2ui_bindingPath(props.value)
-        setMode(date: props.enableDate ?? true, time: props.enableTime ?? false)
+        guard props.enableDate || props.enableTime else {
+            picker.isHidden = true
+            a2ui_applyAccessibility(node.accessibility, dataContext: ctx)
+            return
+        }
+        picker.isHidden = false
+        setMode(date: props.enableDate, time: props.enableTime)
         a2ui_applyAccessibility(node.accessibility, dataContext: ctx)
         setBounds(min: props.min.flatMap { iso.date(from: ctx.resolve($0)) },
                   max: props.max.flatMap { iso.date(from: ctx.resolve($0)) })

--- a/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
@@ -553,12 +553,45 @@ public struct SliderProperties: Codable {
 
 public struct DateTimeInputProperties: Codable {
     public var value: DynamicString
-    public var enableDate: Bool?
-    public var enableTime: Bool?
+    public var enableDate: Bool
+    public var enableTime: Bool
     public var min: DynamicString?
     public var max: DynamicString?
     public var label: DynamicString?
     public var checks: [CheckRule]?
+
+    enum CodingKeys: String, CodingKey {
+        case value, enableDate, enableTime, min, max, label, checks
+    }
+
+    public init(
+        value: DynamicString,
+        enableDate: Bool = false,
+        enableTime: Bool = false,
+        min: DynamicString? = nil,
+        max: DynamicString? = nil,
+        label: DynamicString? = nil,
+        checks: [CheckRule]? = nil
+    ) {
+        self.value = value
+        self.enableDate = enableDate
+        self.enableTime = enableTime
+        self.min = min
+        self.max = max
+        self.label = label
+        self.checks = checks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.value = try container.decode(DynamicString.self, forKey: .value)
+        self.enableDate = try container.decodeIfPresent(Bool.self, forKey: .enableDate) ?? false
+        self.enableTime = try container.decodeIfPresent(Bool.self, forKey: .enableTime) ?? false
+        self.min = try container.decodeIfPresent(DynamicString.self, forKey: .min)
+        self.max = try container.decodeIfPresent(DynamicString.self, forKey: .max)
+        self.label = try container.decodeIfPresent(DynamicString.self, forKey: .label)
+        self.checks = try container.decodeIfPresent([CheckRule].self, forKey: .checks)
+    }
 }
 
 public struct ChoicePickerOption: Codable {

--- a/Sources/A2UISwiftUI/Views/Components/A2UIDateTimeInput.swift
+++ b/Sources/A2UISwiftUI/Views/Components/A2UIDateTimeInput.swift
@@ -41,69 +41,70 @@ struct A2UIDateTimeInput: View {
     var body: some View {
         if let props = try? node.typedProperties(DateTimeInputProperties.self) {
             let dc = DataContext(surface: surface, path: dataContextPath)
-            // ③ Spec v0.9 defaults: enableDate and enableTime are both false when omitted.
-            let enableDate = props.enableDate ?? false
-            let enableTime = props.enableTime ?? false
+            let enableDate = props.enableDate
+            let enableTime = props.enableTime
+            if !enableDate && !enableTime {
+                EmptyView()
+            } else {
 
-            let labelText: String = {
-                if let labelValue = props.label {
-                    return dc.resolve(labelValue)
-                }
-                if enableDate && enableTime { return "Date & Time" }
-                if enableDate { return "Date" }
-                if enableTime { return "Time" }
-                return "Date & Time"
-            }()
-
-            let dtStyle = style.dateTimeInputStyle
-
-            // ② Resolve optional min/max ISO 8601 bounds.
-            let minDate: Date? = props.min.map { dc.resolve($0) }.flatMap { parseISO8601($0) }
-            let maxDate: Date? = props.max.map { dc.resolve($0) }.flatMap { parseISO8601($0) }
-
-            let checksError = dc.firstFailingCheckMessage(props.checks)
-            VStack(alignment: .leading, spacing: 4) {
-                Group {
-                    #if os(tvOS)
-                    VStack(alignment: .leading) {
-                        Text(labelText)
-                            .font(dtStyle.labelFont)
-                            .foregroundStyle(dtStyle.labelColor ?? .primary)
-                        Text(dc.resolve(props.value))
-                            .foregroundStyle(.secondary)
+                let labelText: String = {
+                    if let labelValue = props.label {
+                        return dc.resolve(labelValue)
                     }
-                    #else
-                    let components: DatePicker.Components = {
-                        var c: DatePicker.Components = []
-                        if enableDate { c.insert(.date) }
-                        if enableTime { c.insert(.hourAndMinute) }
-                        if c.isEmpty { c = [.date, .hourAndMinute] }
-                        return c
-                    }()
+                    if enableDate && enableTime { return "Date & Time" }
+                    if enableDate { return "Date" }
+                    return "Time"
+                }()
 
-                    // ② Wire min/max to DatePicker's `in:` range.
-                    datePickerView(
-                        selection: a2uiDateBinding(for: props.value, dataContext: dc),
-                        minDate: minDate,
-                        maxDate: maxDate,
-                        components: components,
-                        label: {
+                let dtStyle = style.dateTimeInputStyle
+
+                // ② Resolve optional min/max ISO 8601 bounds.
+                let minDate: Date? = props.min.map { dc.resolve($0) }.flatMap { parseISO8601($0) }
+                let maxDate: Date? = props.max.map { dc.resolve($0) }.flatMap { parseISO8601($0) }
+
+                let checksError = dc.firstFailingCheckMessage(props.checks)
+                VStack(alignment: .leading, spacing: 4) {
+                    Group {
+                        #if os(tvOS)
+                        VStack(alignment: .leading) {
                             Text(labelText)
                                 .font(dtStyle.labelFont)
                                 .foregroundStyle(dtStyle.labelColor ?? .primary)
+                            Text(dc.resolve(props.value))
+                                .foregroundStyle(.secondary)
                         }
-                    )
-                    .tint(dtStyle.tintColor)
-                    #endif
+                        #else
+                        let components: DatePicker.Components = {
+                            var c: DatePicker.Components = []
+                            if enableDate { c.insert(.date) }
+                            if enableTime { c.insert(.hourAndMinute) }
+                            return c
+                        }()
+
+                        // ② Wire min/max to DatePicker's `in:` range.
+                        datePickerView(
+                            selection: a2uiDateBinding(for: props.value, dataContext: dc),
+                            minDate: minDate,
+                            maxDate: maxDate,
+                            components: components,
+                            label: {
+                                Text(labelText)
+                                    .font(dtStyle.labelFont)
+                                    .foregroundStyle(dtStyle.labelColor ?? .primary)
+                            }
+                        )
+                        .tint(dtStyle.tintColor)
+                        #endif
+                    }
+                    if let msg = checksError {
+                        Text(msg)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
                 }
-                if let msg = checksError {
-                    Text(msg)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
+                .a2uiAccessibility(node.accessibility, dataContext: dc)
+                .padding(style.leafMargin)
             }
-            .a2uiAccessibility(node.accessibility, dataContext: dc)
-            .padding(style.leafMargin)
         }
     }
 

--- a/Tests/A2UISwiftCoreTests/BasicCatalog/DateTimeInputPropertiesTests.swift
+++ b/Tests/A2UISwiftCoreTests/BasicCatalog/DateTimeInputPropertiesTests.swift
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import A2UISwiftCore
+import Foundation
+import Testing
+
+@Suite("DateTimeInput Properties")
+struct DateTimeInputPropertiesTests {
+
+    @Test("defaults enableDate and enableTime to false")
+    func defaultsEnableDateAndEnableTimeToFalse() throws {
+        let json = #"{"value":""}"#.data(using: .utf8)!
+        let props = try JSONDecoder().decode(DateTimeInputProperties.self, from: json)
+
+        #expect(props.enableDate == false)
+        #expect(props.enableTime == false)
+    }
+
+    @Test("preserves explicit enableDate and enableTime values")
+    func preservesExplicitEnableDateAndEnableTimeValues() throws {
+        let json = #"{"value":"","enableDate":true,"enableTime":true}"#.data(using: .utf8)!
+        let props = try JSONDecoder().decode(DateTimeInputProperties.self, from: json)
+
+        #expect(props.enableDate == true)
+        #expect(props.enableTime == true)
+    }
+}


### PR DESCRIPTION
## Summary
- apply the v0.9 DateTimeInput `enableDate` and `enableTime` defaults during property decoding
- make SwiftUI, UIKit, and AppKit DateTimeInput renderers consume the normalized model values directly
- add core decoding tests for omitted and explicit DateTimeInput enable flags

## Root Cause
`DateTimeInputProperties` modeled `enableDate` and `enableTime` as optional values, so omitted fields decoded to `nil`. The SwiftUI renderer handled that as `false`, but the platform renderer treated omitted `enableDate` as `true`, which diverged from the spec default of `false`.

## Validation
- `swift test --filter A2UISwiftCoreTests`
- `swift test`
