### PR TITLE
fix: choicePicker variant default

### DIFF
--- a/Sources/A2UIPlatform/Components/A2UIChoicePicker.swift
+++ b/Sources/A2UIPlatform/Components/A2UIChoicePicker.swift
@@ -66,7 +66,7 @@ final class A2UIChoicePicker: PlatformView, A2UIPlatformComponent {
         dataContext = ctx
         valueBindingPath = a2ui_bindingPath(props.value)
         checks = props.checks
-        multiSelect = (props.variant ?? .mutuallyExclusive) == .multipleSelection
+        multiSelect = props.variant == .multipleSelection
         chips = (props.displayStyle ?? .checkbox) == .chips
         a2ui_applyAccessibility(node.accessibility, dataContext: ctx)
 

--- a/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/ComponentTypes.swift
@@ -604,8 +604,40 @@ public struct ChoicePickerProperties: Codable {
     public var options: [ChoicePickerOption]
     public var value: DynamicStringList?
     public var displayStyle: ChoicePickerDisplayStyle?
-    /// Spec (basic_catalog.json:619-624): default `mutuallyExclusive` when absent.
-    public var variant: ChoicePickerVariant?
+    public var variant: ChoicePickerVariant
     public var filterable: Bool?
     public var checks: [CheckRule]?
+
+    enum CodingKeys: String, CodingKey {
+        case label, options, value, displayStyle, variant, filterable, checks
+    }
+
+    public init(
+        label: DynamicString? = nil,
+        options: [ChoicePickerOption],
+        value: DynamicStringList? = nil,
+        displayStyle: ChoicePickerDisplayStyle? = nil,
+        variant: ChoicePickerVariant = .mutuallyExclusive,
+        filterable: Bool? = nil,
+        checks: [CheckRule]? = nil
+    ) {
+        self.label = label
+        self.options = options
+        self.value = value
+        self.displayStyle = displayStyle
+        self.variant = variant
+        self.filterable = filterable
+        self.checks = checks
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.label = try container.decodeIfPresent(DynamicString.self, forKey: .label)
+        self.options = try container.decode([ChoicePickerOption].self, forKey: .options)
+        self.value = try container.decodeIfPresent(DynamicStringList.self, forKey: .value)
+        self.displayStyle = try container.decodeIfPresent(ChoicePickerDisplayStyle.self, forKey: .displayStyle)
+        self.variant = try container.decodeIfPresent(ChoicePickerVariant.self, forKey: .variant) ?? .mutuallyExclusive
+        self.filterable = try container.decodeIfPresent(Bool.self, forKey: .filterable)
+        self.checks = try container.decodeIfPresent([CheckRule].self, forKey: .checks)
+    }
 }

--- a/Sources/A2UISwiftUI/Views/Components/A2UIChoicePicker.swift
+++ b/Sources/A2UISwiftUI/Views/Components/A2UIChoicePicker.swift
@@ -114,12 +114,8 @@ struct ChoicePickerContent: View {
 
     private var isChips: Bool { properties.displayStyle == .chips }
 
-    /// Spec default: `mutuallyExclusive` when `variant` is absent.
-    /// All v0.9 reference renderers apply this default (Lit/React/Angular via
-    /// Zod `.default()`, Flutter via field-level check). Swift renderer applies
-    /// it explicitly here since the schema validation layer was removed.
     private var isMutuallyExclusive: Bool {
-        switch properties.variant ?? .mutuallyExclusive {
+        switch properties.variant {
         case .mutuallyExclusive: return true
         case .multipleSelection: return false
         case .unknown: return true  // unknown values default to spec default

--- a/Tests/A2UISwiftUITests/ChoicePickerVariantTests.swift
+++ b/Tests/A2UISwiftUITests/ChoicePickerVariantTests.swift
@@ -65,12 +65,12 @@ struct ChoicePickerVariantDecodingTests {
         #expect(props.variant == .multipleSelection)
     }
 
-    @Test("variant is nil when absent (renderer applies spec default)")
-    func variantNilWhenAbsent() throws {
+    @Test("variant defaults to mutuallyExclusive when absent")
+    func variantDefaultsToMutuallyExclusiveWhenAbsent() throws {
         let props = try decode(#"""
         {"options": [{"label": "A", "value": "a"}]}
         """#)
-        #expect(props.variant == nil)
+        #expect(props.variant == .mutuallyExclusive)
     }
 
     @Test("unknown values decode to .unknown for forward-compat")


### PR DESCRIPTION
## Summary
- default `ChoicePickerProperties.variant` to `.mutuallyExclusive` during model decoding when the field is omitted
- make `variant` non-optional so SwiftUI and platform renderers consume normalized schema state
- update ChoicePicker variant tests to assert the spec default

## Validation
- `swift test --filter ChoicePicker`
- `swift test`