### PR TITLE
[codex] Translate existing comments to English

### DIFF
--- a/Sources/A2UISwiftCore/Schema/CommonTypes.swift
+++ b/Sources/A2UISwiftCore/Schema/CommonTypes.swift
@@ -45,7 +45,7 @@ public struct FunctionCall: Codable, Sendable, Equatable {
 
 // MARK: - LiteralDecodable protocol
 
-/// 让泛型 Dynamic<T> 知道如何从 AnyCodable 提取字面量，以及提供默认值。
+/// Lets generic Dynamic<T> extract literals from AnyCodable and provide a default value.
 public protocol LiteralDecodable: Codable {
     static func fromAnyCodable(_ value: AnyCodable) -> Self?
     static var defaultLiteral: Self { get }
@@ -75,8 +75,8 @@ extension Array: LiteralDecodable where Element == String {
 
 // MARK: - Dynamic<T>
 
-/// 泛型动态值：字面量 T | 数据绑定 | 函数调用。
-/// 一份 Codable 实现覆盖 DynamicString / DynamicNumber / DynamicBoolean / DynamicStringList。
+/// Generic dynamic value: literal T | data binding | function call.
+/// One Codable implementation covers DynamicString / DynamicNumber / DynamicBoolean / DynamicStringList.
 public enum Dynamic<T: LiteralDecodable & Sendable>: Codable, Sendable {
     
     case literal(T)
@@ -144,7 +144,7 @@ enum DynamicDictResolver {
 // MARK: - DynamicValue
 
 /// A generic dynamic value: any literal | DataBinding | FunctionCall.
-/// 不适合泛型（多种字面量类型），保持独立 enum。
+/// Not suitable for the generic form because it supports multiple literal types, so it stays as a separate enum.
 /// Mirrors WebCore `DynamicValueSchema`.
 public enum DynamicValue: Codable, Sendable {
     case string(String)

--- a/Sources/A2UISwiftCore/State/DataModel.swift
+++ b/Sources/A2UISwiftCore/State/DataModel.swift
@@ -18,9 +18,9 @@ import Observation
 
 // MARK: - PathSlot
 
-/// 每个数据路径对应一个独立的可观察盒子。
-/// SwiftUI 视图读了哪个盒子，就只跟那个盒子绑定。
-/// 等价于 WebCore 的 `Signal<T>` per path。
+/// Each data path has its own observable box.
+/// A SwiftUI view is bound only to the box it reads.
+/// Equivalent to WebCore's per-path `Signal<T>`.
 /// Internal — not exported. Callers outside the module use DataModel.get() / DataContext.
 /// Mirrors WebCore's internal per-path Signal (not exported from data-model.ts).
 @Observable
@@ -48,13 +48,13 @@ final class PathSlot {
 /// Handles JSON Pointer path resolution (RFC 6901).
 /// Mirrors the behavior of the TypeScript WebCore `DataModel`.
 ///
-/// 提供两种数据访问方式：
-/// - `get(_:)` — 直接取值，不建立观察关系
-/// - `slot(for:)` — 返回路径对应的 PathSlot，SwiftUI 视图通过读 slot.value 建立精细观察
+/// Provides two data access modes:
+/// - `get(_:)` — reads the value directly without creating an observation dependency.
+/// - `slot(for:)` — returns the PathSlot for a path; SwiftUI views read slot.value for fine-grained observation.
 public final class DataModel {
     private var root: AnyCodable
 
-    /// 等价于 TS 的 `Map<string, Signal>`，懒创建。
+    /// Equivalent to the TS `Map<string, Signal>`, created lazily.
     private var slots: [String: PathSlot] = [:]
 
     public init() {
@@ -67,8 +67,8 @@ public final class DataModel {
 
     // MARK: - PathSlot Access
 
-    /// 获取路径对应的 PathSlot（懒创建）。
-    /// SwiftUI 视图应通过此方法读取数据以获得精细粒度的观察。
+    /// Returns the PathSlot for a path, creating it lazily.
+    /// SwiftUI views should read data through this method to get fine-grained observation.
     /// Internal — consumers outside the module use DataContext.resolveDynamicValue().
     func slot(for path: String) -> PathSlot {
         let normalized = normalizePath(path)
@@ -80,7 +80,7 @@ public final class DataModel {
         return newSlot
     }
 
-    /// 清除所有 PathSlot，断开所有观察。
+    /// Clears all PathSlots and disconnects all observations.
     public func dispose() {
         for slot in slots.values {
             slot.onChange.dispose()
@@ -164,13 +164,13 @@ public final class DataModel {
 
     // MARK: - Slot Notification
 
-    /// set() 之后，更新自己、所有祖先、所有后代的 slot。
-    /// 兄弟路径（如 /user/age）不受影响。
+    /// After set(), updates the path's slot, all ancestor slots, and all descendant slots.
+    /// Sibling paths, such as /user/age, are not affected.
     private func notifySlots(for path: String) {
-        // 1. 自己
+        // 1. Self
         updateSlot(at: path)
 
-        // 2. 祖先：/user/name → /user → /
+        // 2. Ancestors: /user/name → /user → /
         var parent = path
         while parent != "/" {
             if let lastSlash = parent.lastIndex(of: "/") {
@@ -181,20 +181,20 @@ public final class DataModel {
             updateSlot(at: parent)
         }
 
-        // 3. 后代：遍历已有 slot，前缀匹配
+        // 3. Descendants: iterate existing slots and match by prefix
         for slotPath in slots.keys where isDescendant(slotPath, of: path) {
             updateSlot(at: slotPath)
         }
     }
 
-    /// 替换 root 时，所有 slot 都要更新。
+    /// When replacing the root, all slots must be updated.
     private func notifyAllSlots() {
         for path in slots.keys {
             updateSlot(at: path)
         }
     }
 
-    /// 用当前 root 重新计算某个 slot 的值。
+    /// Recomputes a slot's value from the current root.
     private func updateSlot(at path: String) {
         guard let slot = slots[path] else { return }
         slot.update(get(path))

--- a/Tests/A2UISwiftCoreTests/Common/EventsTests.swift
+++ b/Tests/A2UISwiftCoreTests/Common/EventsTests.swift
@@ -48,15 +48,15 @@ struct EventsTests {
         #expect(lastValue == "hello")  // unchanged
     }
 
-    // NOTE: WebCore 测试 "handles errors thrown by listeners" 在 Swift 中不适用。
-    // WebCore（TypeScript）的 listener 是无类型约束的，运行时可能抛出任意异常，
-    // 因此 EventEmitter.emit 需要 try-catch 捕获并通过 console.error 记录。
-    // Swift 的类型系统要求 listener 闭包声明为 (T) -> Void（不可抛出），
-    // listener 内部使用 throw 是编译期错误，不存在需要运行时捕获的场景。
+    // NOTE: WebCore's "handles errors thrown by listeners" test does not apply in Swift.
+    // WebCore (TypeScript) listeners are not constrained by the type system and can throw arbitrary runtime exceptions,
+    // so EventEmitter.emit needs try-catch handling and logs through console.error.
+    // Swift's type system requires listener closures to be declared as (T) -> Void (non-throwing);
+    // throwing inside a listener is a compile-time error, so there is no runtime case to catch.
 
-    /// Swift 专属：验证 EventEmitter 的多播（multi-cast）语义——所有订阅者均收到同一事件。
-    /// WebCore 各层代码隐式依赖此行为（如 onUpdated 可被多个视图订阅），但未单独断言。
-    /// Swift 需明确验证，以防止误将实现改为单播（单一 listener 覆盖）。
+    /// Swift-specific: verifies EventEmitter's multi-cast semantics: all subscribers receive the same event.
+    /// WebCore layers implicitly depend on this behavior, such as onUpdated being subscribable by multiple views, but do not assert it separately.
+    /// Swift verifies it explicitly to prevent accidentally changing the implementation to unicast, where one listener overwrites another.
     @Test("multiple subscribers all receive emitted value")
     func multipleSubscribers() {
         let emitter = EventEmitter<Int>()
@@ -68,9 +68,9 @@ struct EventsTests {
         #expect(results == [5, 10])
     }
 
-    /// Swift 专属：验证 dispose() 可一次性移除所有 listener，之后不再触发任何回调。
-    /// WebCore 通过 GC 隐式管理生命周期，无需 dispose。
-    /// Swift 需要主动调用 dispose() 清理订阅以释放内存、防止回调泄漏。
+    /// Swift-specific: verifies dispose() removes all listeners at once and prevents future callbacks.
+    /// WebCore manages lifetimes implicitly through GC and does not need dispose.
+    /// Swift needs explicit dispose() calls to clean up subscriptions, release memory, and prevent callback leaks.
     @Test("dispose removes all listeners")
     func disposeRemovesAll() {
         let emitter = EventEmitter<Int>()
@@ -83,10 +83,10 @@ struct EventsTests {
         #expect(count == 0)
     }
 
-    /// Swift 专属：验证迭代快照（emit-time snapshot）机制的正确性。
-    /// EventEmitter 在 emit 前应先对 listener 列表做快照再迭代，
-    /// 从而保证 listener 内部再次调用 emit 不会造成无限递归或崩溃。
-    /// WebCore 的实现有相同保证，但未通过测试明确约束；Swift 端需显式验证。
+    /// Swift-specific: verifies the correctness of the emit-time snapshot mechanism.
+    /// EventEmitter should snapshot the listener list before iterating during emit,
+    /// ensuring that calling emit again from inside a listener does not cause infinite recursion or crashes.
+    /// WebCore provides the same guarantee but does not pin it with a test; Swift verifies it explicitly.
     @Test("emit during iteration does not crash")
     func emitDuringIteration() {
         let emitter = EventEmitter<Int>()
@@ -102,10 +102,10 @@ struct EventsTests {
         #expect(count == 2)
     }
 
-    /// Swift 专属：验证快照机制确保在 emit 执行期间新注册的 listener
-    /// 不会接收到当次 emit 的事件。
-    /// 快照在 emit 开始时拍摄，新 listener 只出现在下一次 emit 的快照中，
-    /// 避免同一事件被意外重复处理。
+    /// Swift-specific: verifies the snapshot mechanism prevents listeners added during emit
+    /// from receiving the current event.
+    /// The snapshot is taken when emit starts, so new listeners only appear in the next emit snapshot,
+    /// preventing the same event from being processed unexpectedly more than once.
     @Test("new subscriber added during emit does not receive current emit")
     func subscribeDuringEmit() {
         let emitter = EventEmitter<Int>()

--- a/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
+++ b/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
@@ -221,9 +221,9 @@ struct MessageProcessorTests {
 
     @Test("throws on message with multiple update types")
     func throwsMultipleUpdateTypes() {
-        // NOTE: WebCore は JSON の型システム上 as any でキャストして渡すが、
-        // Swift では JSON デコード時点で enum の排他性が保証されるため、
-        // デコード失敗（DecodingError）として捕捉される。
+        // NOTE: WebCore casts this as any under JSON's type system,
+        // but Swift guarantees enum exclusivity during JSON decoding,
+        // so this is caught as a decoding failure (DecodingError).
         let json = """
         {
             "version": "v0.9",
@@ -317,10 +317,10 @@ struct MessageProcessorTests {
 
     @Test("throws when component is missing id")
     func throwsComponentMissingId() {
-        // WebCore 在运行时检查 missing 'id' 并抛出 A2uiValidationError。
-        // Swift 中 RawComponent 的 id 字段是必需的 Codable 属性，
-        // missing id 在 JSON 解码阶段就会产生 DecodingError，
-        // 两者结果等价（均阻止无效组件被创建），但错误类型不同。
+        // WebCore checks for a missing 'id' at runtime and throws A2uiValidationError.
+        // In Swift, RawComponent.id is a required Codable property,
+        // so a missing id produces DecodingError during JSON decoding.
+        // The result is equivalent because both prevent creating the invalid component, but the error type differs.
         let json = """
         [{
             "version": "v0.9",
@@ -398,10 +398,10 @@ struct MessageProcessorTests {
         #expect(processor.resolvePath("foo") == "/foo")
     }
 
-    // NOTE: WebCore 的 getClientCapabilities 测试在 Swift 中不适用。
-    // getClientCapabilities 生成 JSON Schema（基于 Zod schema、REF: 语法转换等），
-    // 这是 TypeScript 服务端专属能力，用于向 LLM 描述可用组件结构。
-    // Swift 实现作为纯客户端渲染器，不负责生成 capabilities，无对应实现。
+    // NOTE: WebCore's getClientCapabilities test does not apply in Swift.
+    // getClientCapabilities generates JSON Schema based on Zod schemas, REF: syntax conversion, and related TypeScript-only machinery.
+    // This is a TypeScript server-side capability used to describe available component structures to an LLM.
+    // The Swift implementation is a pure client renderer and does not generate capabilities, so there is no corresponding implementation.
 
     // MARK: Version compatibility (v0.9 / v0.9.1)
     // v0.9.1 is a backward-compatible refinement of v0.9; schemas accept both

--- a/Tests/A2UISwiftCoreTests/Rendering/DataContextTests.swift
+++ b/Tests/A2UISwiftCoreTests/Rendering/DataContextTests.swift
@@ -29,7 +29,7 @@ private let testData: [String: AnyCodable] = [
 @Suite("DataContext")
 struct DataContextTests {
 
-    // MARK: - resolveDynamicValue (路径解析)
+    // MARK: - resolveDynamicValue (path resolution)
 
     @Test("resolves relative paths")
     func resolvesRelativePaths() {
@@ -91,7 +91,7 @@ struct DataContextTests {
         sub.unsubscribe()
     }
 
-    // MARK: - resolveDynamicValue (字面量)
+    // MARK: - resolveDynamicValue (literals)
 
     @Test("resolves using resolveDynamicValue with literals")
     func resolvesLiterals() {
@@ -124,7 +124,7 @@ struct DataContextTests {
         sub.unsubscribe()
     }
 
-    // MARK: - 函数调用
+    // MARK: - Function calls
 
     @Test("resolves function calls synchronously")
     func resolvesFunctionCallSync() {
@@ -167,7 +167,7 @@ struct DataContextTests {
         #expect(dispatchedError?.code == "EXPRESSION_ERROR")
     }
 
-    // MARK: - 对象不递归解析
+    // MARK: - Objects are not resolved recursively
 
     @Test("does not resolve arbitrary objects recursively")
     func doesNotResolveArbitraryObjectsRecursively() {
@@ -221,7 +221,7 @@ struct DataContextTests {
             DynamicValue.functionCall(FunctionCall(call: "getPi", args: [:]))
         ) { _ in called = true }
 
-        // 初始值正确，但不因无关数据变化而重新调用
+        // The initial value is correct, but unrelated data changes do not invoke the callback again.
         #expect(sub.value == .number(Double.pi))
         #expect(called == false)
         sub.unsubscribe()
@@ -243,9 +243,9 @@ struct DataContextTests {
         if case .dictionary(let outer) = result,
            case .dictionary(let event) = outer["event"],
            case .dictionary(let context) = event["context"] {
-            // data binding 被解析
+            // The data binding is resolved.
             #expect(context["id"] == .string("Alice"))
-            // 数字字面量原样保留
+            // The numeric literal is preserved as-is.
             #expect(context["count"] == .number(42))
         } else {
             Issue.record("resolveAction did not return expected shape")
@@ -322,10 +322,10 @@ struct DataContextTests {
         #expect(dispatchedError?.code == "EXPRESSION_ERROR")
     }
 
-    // NOTE: WebCore 中 "translates ZodError into A2uiExpressionError" 测试
-    // 以及 signal/computed 响应式错误传播测试（"handles errors thrown during reactive
-    // argument resolution" 等）仅适用于 TypeScript 实现：
-    // - ZodError 是 Zod 验证库专属，Swift 端用 Codable/类型系统替代；
-    // - signal/computed 的响应式错误传播是 @preact/signals-core 专属机制，
-    //   Swift 端通过 PathSlot + @Observable 实现，错误在同步调用时即被捕获。
+    // NOTE: WebCore tests such as "translates ZodError into A2uiExpressionError"
+    // and signal/computed reactive error propagation tests ("handles errors thrown during
+    // reactive argument resolution", etc.) apply only to the TypeScript implementation:
+    // - ZodError is specific to the Zod validation library; Swift uses Codable/the type system instead.
+    // - signal/computed reactive error propagation is specific to @preact/signals-core;
+    //   Swift uses PathSlot + @Observable, and errors are caught during the synchronous call.
 }

--- a/Tests/A2UISwiftCoreTests/State/ComponentModelTests.swift
+++ b/Tests/A2UISwiftCoreTests/State/ComponentModelTests.swift
@@ -19,7 +19,7 @@ import Observation
 @Suite("ComponentModel")
 struct ComponentModelTests {
 
-    // -- 初始化 --
+    // -- Initialization --
 
     @Test("initializes properties")
     func initialization() {
@@ -31,7 +31,7 @@ struct ComponentModelTests {
         #expect(comp.properties["label"] == .string("Click Me"))
     }
 
-    // -- 属性更新 --
+    // -- Property updates --
 
     @Test("updates properties")
     func updateProperties() {
@@ -86,11 +86,11 @@ struct ComponentModelTests {
         #expect(tree["label"] == .string("Click Me"))
     }
 
-    // -- @Observable (Swift 专属) --
+    // -- @Observable (Swift-specific) --
 
-    /// Swift 专属：验证 @Observable 宏在属性整体替换时触发 observation，
-    /// 使 SwiftUI View 能正确重新渲染。WebCore 通过响应式信号系统（Preact signals）
-    /// 实现细粒度更新；Swift 端对应机制是 @Observable，需专门验证。
+    /// Swift-specific: verifies that the @Observable macro triggers observation when properties are replaced as a whole,
+    /// allowing SwiftUI views to re-render correctly. WebCore uses a reactive signal system (Preact signals)
+    /// for fine-grained updates; Swift's equivalent mechanism is @Observable, so it needs dedicated coverage.
     @Test("observation triggers on properties replacement")
     func observationOnReplacement() {
         let comp = ComponentModel(id: "c1", type: "Button", properties: [
@@ -108,9 +108,9 @@ struct ComponentModelTests {
         #expect(flag.triggered == true)
     }
 
-    /// Swift 专属：验证通过下标（subscript）对单个属性的修改也会触发 @Observable 通知。
-    /// SwiftUI View 只订阅了 comp.properties 整体，subscript 写入需同样触发通知，
-    /// 否则视图将无法感知细粒度属性变化。
+    /// Swift-specific: verifies that mutating a single property through subscript also triggers @Observable notification.
+    /// SwiftUI views subscribe to comp.properties as a whole, so subscript writes must trigger notification as well,
+    /// otherwise views cannot observe fine-grained property changes.
     @Test("observation triggers on single property mutation")
     func observationOnMutation() {
         let comp = ComponentModel(id: "c1", type: "Button", properties: [

--- a/Tests/A2UISwiftCoreTests/State/DataModelTests.swift
+++ b/Tests/A2UISwiftCoreTests/State/DataModelTests.swift
@@ -126,9 +126,9 @@ struct DataModelSetTests {
         #expect(user?.keys.contains("name") == false)
     }
 
-    // NOTE: WebCore 同时测试了订阅者在 root 替换时触发一次（callCount == 1），
-    // 以及 get("") 等价 get("/")。Swift 将订阅行为独立放在 Subscriptions suite，
-    // 这里只验证数据写入正确，保持 Updates suite 职责单一。
+    // NOTE: WebCore also tests that subscribers fire once when the root is replaced (callCount == 1),
+    // and that get("") is equivalent to get("/"). Swift keeps subscription behavior in the Subscriptions suite,
+    // so this test only verifies data writes and keeps the Updates suite focused.
     @Test("replaces root object on root update")
     func replaceRoot() throws {
         let model = makeModel()
@@ -382,23 +382,23 @@ struct DataModelSubscriptionTests {
         #expect(callCount == 1)
     }
 
-    // NOTE: WebCore 测试 "throws when path is null or undefined" 以及
-    // "calculates descendants against root path" 在 Swift 中不适用：
-    // Swift 类型系统在编译期禁止传 nil 给 String 参数，不存在需要运行时抛错的场景；
-    // isDescendant 是内部实现细节，测试私有方法在 Swift 中需破坏封装，不适用。
+    // NOTE: WebCore tests "throws when path is null or undefined" and
+    // "calculates descendants against root path" do not apply in Swift:
+    // Swift's type system prevents passing nil to String parameters at compile time, so there is no runtime error case;
+    // isDescendant is an internal implementation detail, and testing private methods would break encapsulation in Swift.
 }
 
-// MARK: - PathSlot Observation (Swift 专属)
+// MARK: - PathSlot Observation (Swift-specific)
 
-/// Swift 专属：PathSlot 是对 WebCore DataModel.subscribe() 返回的订阅对象的 Swift 封装，
-/// 额外支持 @Observable 宏，使 SwiftUI View 可以直接读取 slot.value 并在数据变更时
-/// 自动重新渲染，无需手动管理回调。这些测试验证 PathSlot 的 @Observable 行为符合预期。
+/// Swift-specific: PathSlot is Swift's wrapper for the subscription object returned by WebCore DataModel.subscribe().
+/// It additionally supports the @Observable macro, allowing SwiftUI views to read slot.value directly and
+/// automatically re-render when data changes without manual callback management. These tests verify PathSlot's @Observable behavior.
 @Suite("PathSlot Observation")
 struct DataModelSlotObservationTests {
 
-    /// 验证 slot 是懒创建且被缓存的——对同一路径多次调用 slot(for:) 返回同一实例。
-    /// SwiftUI View 可能在 body 中多次读取同一路径的 slot，若每次创建新实例则会
-    /// 丢失已订阅的 onChange 监听，导致视图失去响应性。
+    /// Verifies that slots are created lazily and cached: repeated slot(for:) calls for the same path return the same instance.
+    /// SwiftUI views may read the same path's slot multiple times in body; if each read created a new instance,
+    /// the subscribed onChange listener would be lost and the view would stop responding.
     @Test("slot is lazily created and cached")
     func slotIdentity() {
         let model = makeModel()
@@ -407,8 +407,8 @@ struct DataModelSlotObservationTests {
         #expect(slot1 === slot2)
     }
 
-    /// 验证 @Observable 的细粒度精度：只有被访问路径的 slot 变化才会触发 onChange，
-    /// 与该路径无关的 slot 不应触发，确保 SwiftUI View 不会因不相关数据变化而重渲染。
+    /// Verifies @Observable's fine-grained precision: only changes to the accessed path's slot should trigger onChange.
+    /// Slots unrelated to that path should not trigger, ensuring SwiftUI views do not re-render for unrelated data changes.
     @Test("observation only triggers for the accessed slot")
     func observationGranularity() throws {
         let model = makeModel()


### PR DESCRIPTION
## Summary
- translate existing Chinese/Japanese code comments and doc comments to English
- keep the change limited to existing comments, with no new explanatory comments or behavior changes
- verify no remaining Han/Hiragana/Katakana characters in the Swift repo

## Validation
- `rg -n "[\\p{Han}\\p{Hiragana}\\p{Katakana}]"`
- `swift test`