### PR TITLE
fix: remove redundant internal setter

### DIFF
--- a/Sources/A2UISwiftCore/State/DataModel.swift
+++ b/Sources/A2UISwiftCore/State/DataModel.swift
@@ -25,7 +25,7 @@ import Observation
 /// Mirrors WebCore's internal per-path Signal (not exported from data-model.ts).
 @Observable
 final class PathSlot {
-    internal(set) var value: AnyCodable?
+    var value: AnyCodable?
 
     /// Synchronous notification emitter — fired whenever the slot's value changes.
     /// Used by `DataContext.subscribeDynamicValue` to deliver reactive updates immediately.


### PR DESCRIPTION
## Summary
- remove redundant `internal(set)` from internal `PathSlot.value`
- clear the Swift compiler warning without changing access outside the module

## Validation
- `swift test --filter DataModel`