### PR TITLE
feat: support inline catalog generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,10 @@ let package = Package(
             url: "https://github.com/swiftlang/swift-foundation-icu.git",
             revision: "swift-6.3.1-RELEASE"
         ),
+        .package(
+            url: "https://github.com/ajevans99/swift-json-schema.git",
+            .upToNextMinor(from: "0.13.1")
+        ),
     ],
     targets: [
         .target(
@@ -72,6 +76,8 @@ let package = Package(
             name: "A2UISwiftCore",
             dependencies: [
                 .product(name: "_FoundationICU", package: "swift-foundation-icu"),
+                .product(name: "JSONSchema", package: "swift-json-schema"),
+                .product(name: "OrderedJSON", package: "swift-json-schema"),
             ],
             path: "Sources/A2UISwiftCore"
         ),
@@ -114,7 +120,10 @@ let package = Package(
         ),
         .testTarget(
             name: "A2UISwiftCoreTests",
-            dependencies: ["A2UISwiftCore"],
+            dependencies: [
+                "A2UISwiftCore",
+                .product(name: "JSONSchemaBuilder", package: "swift-json-schema"),
+            ],
             path: "Tests/A2UISwiftCoreTests"
         ),
         .testTarget(

--- a/Sources/A2UISwiftCore/Catalog/Types.swift
+++ b/Sources/A2UISwiftCore/Catalog/Types.swift
@@ -13,8 +13,30 @@
 // limitations under the License.
 
 import Foundation
+import JSONSchema
 
 // MARK: - Catalog
+
+/// A function schema definition stored by a catalog before it is converted to
+/// the wire-format `FunctionDefinition` used by client capabilities.
+public struct CatalogFunctionApi {
+    public let name: String
+    public let description: String?
+    public let parameters: Schema
+    public let returnType: FunctionCallReturnType
+
+    public init(
+        name: String,
+        description: String? = nil,
+        parameters: Schema,
+        returnType: FunctionCallReturnType
+    ) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.returnType = returnType
+    }
+}
 
 /// A collection of available component type names and optional function implementations.
 /// Mirrors WebCore `Catalog` in catalog/types.ts.
@@ -25,8 +47,17 @@ public final class Catalog {
     /// The set of known component type names (e.g. ["Button", "Text"]).
     public let componentNames: Set<String>
 
+    /// JSON Schemas for component properties, keyed by component name.
+    public let componentSchemas: [String: Schema]
+
     /// Named function implementations, keyed by function name.
     public let functions: [String: FunctionInvoker]
+
+    /// Function schemas and return-type metadata used for inline catalog generation.
+    public let functionApis: [CatalogFunctionApi]
+
+    /// JSON Schema for theme parameters used by this catalog.
+    public let themeSchema: Schema?
 
     /// A ready-to-use FunctionInvoker that delegates to this catalog's registered functions.
     /// Mirrors WebCore `Catalog.invoker`.
@@ -43,10 +74,16 @@ public final class Catalog {
     public init(
         id: String,
         componentNames: Set<String> = [],
-        functions: [String: FunctionInvoker] = [:]
+        componentSchemas: [String: Schema] = [:],
+        functions: [String: FunctionInvoker] = [:],
+        functionApis: [CatalogFunctionApi] = [],
+        themeSchema: Schema? = nil
     ) {
         self.id = id
-        self.componentNames = componentNames
+        self.componentNames = componentNames.union(componentSchemas.keys)
+        self.componentSchemas = componentSchemas
         self.functions = functions
+        self.functionApis = functionApis
+        self.themeSchema = themeSchema
     }
 }

--- a/Sources/A2UISwiftCore/Processing/MessageProcessor.swift
+++ b/Sources/A2UISwiftCore/Processing/MessageProcessor.swift
@@ -14,6 +14,17 @@
 
 import Foundation
 
+// MARK: - CapabilitiesOptions
+
+/// Options for client capability generation.
+public struct CapabilitiesOptions: Sendable {
+    public let includeInlineCatalogs: Bool
+
+    public init(includeInlineCatalogs: Bool = false) {
+        self.includeInlineCatalogs = includeInlineCatalogs
+    }
+}
+
 // MARK: - MessageProcessor
 
 /// The central processor for A2UI server-to-client messages.
@@ -78,7 +89,97 @@ public final class MessageProcessor {
     /// // Attach to your A2A/HTTP transport metadata
     /// ```
     public var clientCapabilities: A2uiClientCapabilities {
-        A2uiClientCapabilities.make(from: catalogs)
+        getClientCapabilities()
+    }
+
+    /// Generates the client capabilities for this renderer.
+    ///
+    /// When `includeInlineCatalogs` is true, the processor converts catalog
+    /// component/function/theme schemas into the inline catalog payload defined
+    /// by the spec. Per spec, callers should only request inline catalogs when
+    /// the agent has advertised `acceptsInlineCatalogs: true`.
+    public func getClientCapabilities(
+        options: CapabilitiesOptions = CapabilitiesOptions()
+    ) -> A2uiClientCapabilities {
+        A2uiClientCapabilities.make(
+            from: catalogs,
+            inlineCatalogs: options.includeInlineCatalogs
+                ? catalogs.map(generateInlineCatalog)
+                : nil
+        )
+    }
+
+    private func generateInlineCatalog(_ catalog: Catalog) -> InlineCatalog {
+        let components = catalog.componentSchemas.reduce(into: [String: AnyCodable]()) { result, pair in
+            result[pair.key] = makeInlineComponentSchema(
+                name: pair.key,
+                propertiesSchema: processRefs(pair.value.anyCodableSchema)
+            )
+        }
+
+        let functions = catalog.functionApis.map { api in
+            FunctionDefinition(
+                name: api.name,
+                description: api.description,
+                parameters: processRefs(api.parameters.anyCodableSchema),
+                returnType: api.returnType
+            )
+        }
+
+        let theme = catalog.themeSchema
+            .map { processRefs($0.anyCodableSchema) }
+            .flatMap { $0.dictionaryValue?["properties"]?.dictionaryValue }
+
+        return InlineCatalog(
+            catalogId: catalog.id,
+            components: components.isEmpty ? nil : components,
+            functions: functions.isEmpty ? nil : functions,
+            theme: theme
+        )
+    }
+
+    private func makeInlineComponentSchema(name: String, propertiesSchema: AnyCodable) -> AnyCodable {
+        let schema = propertiesSchema.dictionaryValue ?? [:]
+        let required = schema["required"]?.arrayValue ?? []
+        let properties = schema["properties"]?.dictionaryValue ?? [:]
+        let userRequired = required.filter { $0.stringValue != "component" }
+
+        return .dictionary([
+            "allOf": .array([
+                .dictionary(["$ref": .string("common_types.json#/$defs/ComponentCommon")]),
+                .dictionary([
+                    "properties": .dictionary(
+                        properties.merging(["component": .dictionary(["const": .string(name)])]) { _, generated in
+                            generated
+                        }
+                    ),
+                    "required": .array([.string("component")] + userRequired),
+                ]),
+            ]),
+        ])
+    }
+
+    private func processRefs(_ node: AnyCodable) -> AnyCodable {
+        switch node {
+        case .dictionary(let dictionary):
+            if let description = dictionary["description"]?.stringValue,
+               description.hasPrefix("REF:") {
+                let raw = String(description.dropFirst(4))
+                let parts = raw.split(separator: "|", omittingEmptySubsequences: false)
+                var result: [String: AnyCodable] = [
+                    "$ref": .string(String(parts.first ?? ""))
+                ]
+                if parts.count > 1, !parts[1].isEmpty {
+                    result["description"] = .string(String(parts[1]))
+                }
+                return .dictionary(result)
+            }
+            return .dictionary(dictionary.mapValues(processRefs))
+        case .array(let array):
+            return .array(array.map(processRefs))
+        default:
+            return node
+        }
     }
 
     // MARK: - Path Resolution

--- a/Sources/A2UISwiftCore/Schema/JSONSchemaConversion.swift
+++ b/Sources/A2UISwiftCore/Schema/JSONSchemaConversion.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JSONSchema
+import OrderedJSON
+
+extension AnyCodable {
+    init(jsonValue: JSONValue) {
+        switch jsonValue {
+        case .string(let value):
+            self = .string(value)
+        case .number(let value):
+            self = .number(value)
+        case .integer(let value):
+            self = .number(Double(value))
+        case .object(let value):
+            self = .dictionary(value.reduce(into: [:]) { result, pair in
+                result[pair.key] = AnyCodable(jsonValue: pair.value)
+            })
+        case .array(let value):
+            self = .array(value.map { AnyCodable(jsonValue: $0) })
+        case .boolean(let value):
+            self = .bool(value)
+        case .null:
+            self = .null
+        }
+    }
+}
+
+extension Schema {
+    var anyCodableSchema: AnyCodable {
+        AnyCodable(jsonValue: jsonValue)
+    }
+}

--- a/Sources/Primitives/Part.swift
+++ b/Sources/Primitives/Part.swift
@@ -22,7 +22,7 @@ public protocol Part: Equatable, Sendable {
 public let partTypeKey = "type"
 
 /// A closure that converts a JSON dictionary to a `Part`.
-public typealias JsonToPartConverter = ([String: Any?]) throws -> any Part
+public typealias JsonToPartConverter = @Sendable ([String: Any?]) throws -> any Part
 
 /// Deserializes a part from a JSON dictionary.
 ///

--- a/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
+++ b/Tests/A2UISwiftCoreTests/Processing/MessageProcessorTests.swift
@@ -15,8 +15,24 @@
 @testable import A2UISwiftCore
 import Testing
 import Foundation
+import JSONSchema
+import JSONSchemaBuilder
 
 // MARK: - Helpers
+
+@Schemable
+@ObjectOptions(.additionalProperties { false })
+struct GeneratedChartProperties {
+    let title: String
+    let data: [Double]
+    let xAxisLabel: String
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case data
+        case xAxisLabel = "x_axis_label"
+    }
+}
 
 private func makeProcessor(
     catalogId: String = "test-catalog",
@@ -24,6 +40,10 @@ private func makeProcessor(
 ) -> MessageProcessor {
     let catalog = Catalog(id: catalogId)
     return MessageProcessor(catalogs: [catalog], actionHandler: actionHandler)
+}
+
+private func makeSchema(_ json: String) throws -> Schema {
+    try Schema(instance: json)
 }
 
 private func createSurfaceMsg(
@@ -398,10 +418,191 @@ struct MessageProcessorTests {
         #expect(processor.resolvePath("foo") == "/foo")
     }
 
-    // NOTE: WebCore's getClientCapabilities test does not apply in Swift.
-    // getClientCapabilities generates JSON Schema based on Zod schemas, REF: syntax conversion, and related TypeScript-only machinery.
-    // This is a TypeScript server-side capability used to describe available component structures to an LLM.
-    // The Swift implementation is a pure client renderer and does not generate capabilities, so there is no corresponding implementation.
+    // MARK: Client capabilities
+
+    @Test("clientCapabilities omits inline catalogs by default")
+    func clientCapabilitiesOmitsInlineCatalogsByDefault() throws {
+        let catalog = Catalog(
+            id: "custom-catalog",
+            componentSchemas: ["Custom": try makeSchema(#"{"type":"object"}"#)]
+        )
+        let processor = MessageProcessor(catalogs: [catalog])
+
+        let capabilities = processor.clientCapabilities
+
+        #expect(capabilities.v09.supportedCatalogIds == ["custom-catalog"])
+        #expect(capabilities.v09.inlineCatalogs == nil)
+    }
+
+    @Test("getClientCapabilities includes inline component catalogs when requested")
+    func getClientCapabilitiesIncludesInlineComponentCatalogs() throws {
+        let catalog = Catalog(
+            id: "custom-catalog",
+            componentSchemas: [
+                "Custom": try makeSchema(
+                    """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "title": { "type": "string" },
+                        "child": {
+                          "description": "REF:common_types.json#/$defs/ComponentId|Child component id"
+                        },
+                        "noPipe": {
+                          "description": "REF:common_types.json#/$defs/NoPipe"
+                        },
+                        "multiPipe": {
+                          "description": "REF:common_types.json#/$defs/MultiPipe|First|Second"
+                        },
+                        "component": {
+                          "const": "WrongComponent"
+                        }
+                      },
+                      "required": ["component", "title"]
+                    }
+                    """
+                )
+            ]
+        )
+        let processor = MessageProcessor(catalogs: [catalog])
+
+        let capabilities = processor.getClientCapabilities(
+            options: CapabilitiesOptions(includeInlineCatalogs: true)
+        )
+
+        guard let inline = capabilities.v09.inlineCatalogs?.first,
+              let custom = inline.components?["Custom"]?.dictionaryValue,
+              let allOf = custom["allOf"]?.arrayValue,
+              allOf.count == 2,
+              let componentEnvelope = allOf[0].dictionaryValue,
+              let customSchema = allOf[1].dictionaryValue,
+              let properties = customSchema["properties"]?.dictionaryValue,
+              let component = properties["component"]?.dictionaryValue,
+              let child = properties["child"]?.dictionaryValue,
+              let noPipe = properties["noPipe"]?.dictionaryValue,
+              let multiPipe = properties["multiPipe"]?.dictionaryValue,
+              let required = customSchema["required"]?.arrayValue
+        else {
+            Issue.record("expected inline component schema")
+            return
+        }
+
+        #expect(inline.catalogId == "custom-catalog")
+        #expect(componentEnvelope["$ref"] == .string("common_types.json#/$defs/ComponentCommon"))
+        #expect(component["const"] == .string("Custom"))
+        #expect(child["$ref"] == .string("common_types.json#/$defs/ComponentId"))
+        #expect(child["description"] == .string("Child component id"))
+        #expect(noPipe["$ref"] == .string("common_types.json#/$defs/NoPipe"))
+        #expect(noPipe["description"] == nil)
+        #expect(multiPipe["$ref"] == .string("common_types.json#/$defs/MultiPipe"))
+        #expect(multiPipe["description"] == .string("First"))
+        #expect(required == [.string("component"), .string("title")])
+        #expect(required.filter { $0 == .string("component") }.count == 1)
+    }
+
+    @Test("getClientCapabilities accepts component schemas generated from Swift models")
+    func getClientCapabilitiesIncludesGeneratedModelSchemas() throws {
+        let catalog = Catalog(
+            id: "custom-catalog",
+            componentSchemas: [
+                "Chart": GeneratedChartProperties.schema.definition()
+            ]
+        )
+        let processor = MessageProcessor(catalogs: [catalog])
+
+        let capabilities = processor.getClientCapabilities(
+            options: CapabilitiesOptions(includeInlineCatalogs: true)
+        )
+
+        guard let inline = capabilities.v09.inlineCatalogs?.first,
+              let chart = inline.components?["Chart"]?.dictionaryValue,
+              let allOf = chart["allOf"]?.arrayValue,
+              allOf.count == 2,
+              let commonEnvelope = allOf[0].dictionaryValue,
+              let chartSchema = allOf[1].dictionaryValue,
+              let properties = chartSchema["properties"]?.dictionaryValue,
+              let component = properties["component"]?.dictionaryValue,
+              let title = properties["title"]?.dictionaryValue,
+              let data = properties["data"]?.dictionaryValue,
+              let xAxisLabel = properties["x_axis_label"]?.dictionaryValue,
+              let dataItems = data["items"]?.dictionaryValue,
+              let required = chartSchema["required"]?.arrayValue
+        else {
+            Issue.record("expected generated model schema in inline component catalog")
+            return
+        }
+
+        #expect(inline.catalogId == "custom-catalog")
+        #expect(commonEnvelope["$ref"] == .string("common_types.json#/$defs/ComponentCommon"))
+        #expect(component["const"] == .string("Chart"))
+        #expect(title["type"] == .string("string"))
+        #expect(data["type"] == .string("array"))
+        #expect(dataItems["type"] == .string("number"))
+        #expect(xAxisLabel["type"] == .string("string"))
+        #expect(chartSchema["additionalProperties"] == nil)
+        #expect(required == [
+            .string("component"),
+            .string("title"),
+            .string("data"),
+            .string("x_axis_label"),
+        ])
+    }
+
+    @Test("getClientCapabilities includes functions and theme schemas when requested")
+    func getClientCapabilitiesIncludesFunctionsAndThemeSchemas() throws {
+        let catalog = Catalog(
+            id: "custom-catalog",
+            functions: [
+                "format": { _, _, _ in .string("ok") }
+            ],
+            functionApis: [
+                CatalogFunctionApi(
+                    name: "format",
+                    description: "Formats a value",
+                    parameters: try makeSchema(
+                        """
+                        {
+                          "type": "object",
+                          "properties": { "value": { "type": "string" } },
+                          "required": ["value"]
+                        }
+                        """
+                    ),
+                    returnType: .string
+                )
+            ],
+            themeSchema: try makeSchema(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "primaryColor": { "type": "string" }
+                  }
+                }
+                """
+            )
+        )
+        let processor = MessageProcessor(catalogs: [catalog])
+
+        let capabilities = processor.getClientCapabilities(
+            options: CapabilitiesOptions(includeInlineCatalogs: true)
+        )
+
+        guard let inline = capabilities.v09.inlineCatalogs?.first,
+              let function = inline.functions?.first,
+              let parameters = function.parameters.dictionaryValue,
+              let theme = inline.theme
+        else {
+            Issue.record("expected inline function and theme schemas")
+            return
+        }
+
+        #expect(function.name == "format")
+        #expect(function.description == "Formats a value")
+        #expect(function.returnType == .string)
+        #expect(parameters["type"] == .string("object"))
+        #expect(theme["primaryColor"]?.dictionaryValue?["type"] == .string("string"))
+    }
 
     // MARK: Version compatibility (v0.9 / v0.9.1)
     // v0.9.1 is a backward-compatible refinement of v0.9; schemas accept both

--- a/Tests/PrimitivesTests/CustomPartTests.swift
+++ b/Tests/PrimitivesTests/CustomPartTests.swift
@@ -19,7 +19,7 @@ struct CustomPart: Part, Sendable {
 }
 
 /// A converter for CustomPart.
-func customPartConverter(_ json: [String: Any?]) throws -> any Part {
+private let customPartConverter: JsonToPartConverter = { json in
     guard let type = json["type"] as? String, type == "Custom" else {
         throw PartError.unknownType(json["type"] as? String ?? "nil")
     }

--- a/samples/sample_0.9/A2UISwiftUIDemo/A2UISwiftUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/samples/sample_0.9/A2UISwiftUIDemo/A2UISwiftUIDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78e293cf77322b36117ac831839baa4a9c20d261b9c0fdb3cab52a873a9a336f",
+  "originHash" : "c78857f79394481a17b201c10d87bc23281c89bb8bedda5c739c53dba99f52ce",
   "pins" : [
     {
       "identity" : "icu-mirror",
@@ -8,6 +8,33 @@
       "state" : {
         "branch" : "swift-6.3.1-RELEASE",
         "revision" : "2e2854eee567589ed44c5f3c85c7343e6d91978d"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-json-schema",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ajevans99/swift-json-schema.git",
+      "state" : {
+        "revision" : "f299eb1cce78b2dd736d9a390ec0779d28678416",
+        "version" : "0.13.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- add JSONSchema-backed catalog schema metadata in A2UISwiftCore
- add getClientCapabilities(options:) with includeInlineCatalogs support
- generate inline component/function/theme catalogs using the official renderer shape, including ComponentCommon wrapping and REF conversion
- mark primitive part converters @Sendable for Swift 6 concurrency safety

## Validation
- swift test --filter PrimitivesTests
- swift test --filter getClientCapabilities
- swift test