### PR TITLE
test: add A2UI conformance test harness

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,5 +137,11 @@ let package = Package(
             dependencies: ["A2UISwiftCore", "A2UIPlatform"],
             path: "Tests/A2UIPlatformTests"
         ),
+        .testTarget(
+            name: "A2UIConformanceTests",
+            dependencies: ["A2UISwiftCore"],
+            path: "Tests/A2UIConformanceTests",
+            resources: [.copy("Resources")]
+        ),
     ]
 )

--- a/Tests/A2UIConformanceTests/CatalogConformanceTests.swift
+++ b/Tests/A2UIConformanceTests/CatalogConformanceTests.swift
@@ -1,0 +1,18 @@
+// Tests/A2UIConformanceTests/CatalogConformanceTests.swift
+import XCTest
+@testable import A2UISwiftCore
+
+final class CatalogConformanceTests: XCTestCase {
+
+    private static var cases: [ConformanceCase] = {
+        (try? loadConformanceCases(suite: "catalog")) ?? []
+    }()
+
+    func test_catalog_conformance() throws {
+        let cases = CatalogConformanceTests.cases
+        guard !cases.isEmpty else {
+            throw XCTSkip("Could not load conformance cases for 'catalog' — check Bundle.module resources")
+        }
+        throw XCTSkip("N/A for renderer: all catalog suite actions are agent-side")
+    }
+}

--- a/Tests/A2UIConformanceTests/ConformanceCase.swift
+++ b/Tests/A2UIConformanceTests/ConformanceCase.swift
@@ -1,0 +1,149 @@
+// Tests/A2UIConformanceTests/ConformanceCase.swift
+import Foundation
+import XCTest
+
+struct ConformanceCatalogConfig {
+    let version: String           // "0.8" or "0.9"
+    let s2cSchema: Any?           // [String: Any] or nil
+    let catalogSchema: Any?       // [String: Any] or nil
+    let commonTypesSchema: Any?   // [String: Any] or nil
+}
+
+struct ConformanceExpectedError {
+    let category: String          // "ParseError", "ValidationError", etc.
+    let message: String?
+}
+
+struct ConformanceStep {
+    let input: String?            // for process_chunk / parse_full / fix_payload / has_parts
+    let payload: Any?             // for validate (array of messages)
+    let args: [String: Any]?      // for prune, load, select_catalog, etc.
+    let expect: Any?              // expected output (array of parts, mapping, etc.)
+    let expectOutput: String?     // for render / load actions
+    let expectError: ConformanceExpectedError?
+    let expectSelected: String?   // for select_catalog
+}
+
+struct ConformanceCase {
+    let name: String
+    let description: String?
+    let catalog: ConformanceCatalogConfig?
+    let action: String
+    let steps: [ConformanceStep]
+}
+
+// MARK: - Loaders
+
+func loadTestDataJSON(path: String) throws -> Any {
+    // path may be like "test_data/simplified_s2c_v08.json" — strip the prefix
+    let strippedPath = path.hasPrefix("test_data/") ? String(path.dropFirst("test_data/".count)) : path
+    let fileURL = URL(fileURLWithPath: strippedPath)
+    let filename = fileURL.deletingPathExtension().lastPathComponent
+    let ext = fileURL.pathExtension
+
+    guard let url = Bundle.module.url(
+        forResource: filename,
+        withExtension: ext.isEmpty ? nil : ext,
+        subdirectory: "Resources/test_data"
+    ) else {
+        throw YAMLError.parse("test_data file not found: \(path)")
+    }
+    let data = try Data(contentsOf: url)
+    return try JSONSerialization.jsonObject(with: data)
+}
+
+func loadConformanceCases(suite: String) throws -> [ConformanceCase] {
+    guard let url = Bundle.module.url(
+        forResource: suite,
+        withExtension: "yaml",
+        subdirectory: "Resources/suites"
+    ) else {
+        throw YAMLError.parse("Suite not found: \(suite).yaml")
+    }
+    let text = try String(contentsOf: url, encoding: .utf8)
+    let parsed = try parseYAML(text)
+    guard let rawCases = parsed as? [[String: Any]] else {
+        throw YAMLError.parse("Expected array of mappings in \(suite).yaml")
+    }
+    return try rawCases.map { try decodeCase($0) }
+}
+
+// MARK: - Private helpers
+
+private func decodeCase(_ d: [String: Any]) throws -> ConformanceCase {
+    guard let name = d["name"] as? String else {
+        throw YAMLError.parse("Case missing 'name'")
+    }
+    let action = d["action"] as? String ?? "process_chunk"
+
+    let catalogConfig: ConformanceCatalogConfig?
+    if let catalogDict = d["catalog"] as? [String: Any] {
+        catalogConfig = try decodeCatalogConfig(catalogDict)
+    } else {
+        catalogConfig = nil
+    }
+
+    // Collect steps: either explicit "steps" array, or the case itself is one step
+    let rawSteps: [[String: Any]]
+    if let stepsArray = d["steps"] as? [[String: Any]] {
+        rawSteps = stepsArray
+    } else {
+        rawSteps = [d]
+    }
+
+    // Top-level expect_error propagates to steps that don't have their own
+    let topLevelError = decodeExpectedError(d)
+    let steps = rawSteps.map { decodeStep($0, fallbackError: topLevelError) }
+
+    return ConformanceCase(
+        name: name,
+        description: d["description"] as? String,
+        catalog: catalogConfig,
+        action: action,
+        steps: steps
+    )
+}
+
+private func decodeCatalogConfig(_ d: [String: Any]) throws -> ConformanceCatalogConfig {
+    let version = d["version"] as? String ?? "0.9"
+
+    func resolveSchema(_ key: String) throws -> Any? {
+        guard let val = d[key] else { return nil }
+        if let path = val as? String {
+            return try loadTestDataJSON(path: path)
+        }
+        return val
+    }
+
+    return ConformanceCatalogConfig(
+        version: version,
+        s2cSchema: try resolveSchema("s2c_schema"),
+        catalogSchema: try resolveSchema("catalog_schema"),
+        commonTypesSchema: try resolveSchema("common_types_schema")
+    )
+}
+
+private func decodeExpectedError(_ d: [String: Any]) -> ConformanceExpectedError? {
+    if let errDict = d["expect_error"] as? [String: Any] {
+        return ConformanceExpectedError(
+            category: errDict["category"] as? String ?? "",
+            message: errDict["message"] as? String
+        )
+    } else if let errStr = d["expect_error"] as? String {
+        return ConformanceExpectedError(category: "ParseError", message: errStr)
+    }
+    return nil
+}
+
+private func decodeStep(_ d: [String: Any], fallbackError: ConformanceExpectedError? = nil) -> ConformanceStep {
+    let expectError = decodeExpectedError(d) ?? fallbackError
+    return ConformanceStep(
+        input: d["input"] as? String,
+        payload: d["payload"],
+        args: d["args"] as? [String: Any],
+        expect: d["expect"],
+        expectOutput: d["expect_output"] as? String,
+        expectError: expectError,
+        expectSelected: d["expect_selected"] as? String
+    )
+}

--- a/Tests/A2UIConformanceTests/ConformanceCaseTests.swift
+++ b/Tests/A2UIConformanceTests/ConformanceCaseTests.swift
@@ -1,0 +1,57 @@
+// Tests/A2UIConformanceTests/ConformanceCaseTests.swift
+import XCTest
+import Foundation
+
+final class ConformanceCaseTests: XCTestCase {
+
+    func test_loadsParserSuite() throws {
+        let cases = try loadConformanceCases(suite: "parser")
+        XCTAssertEqual(cases.count, 19, "parser.yaml should have 19 test cases, got \(cases.count)")
+        let names = cases.map(\.name)
+        XCTAssertTrue(names.contains("test_parse_empty_response"),
+            "Expected 'test_parse_empty_response' in parser suite")
+    }
+
+    func test_loadsAllSuites() throws {
+        let suites = ["parser", "streaming_parser", "catalog", "validator", "schema_manager"]
+        for suite in suites {
+            let cases = try loadConformanceCases(suite: suite)
+            XCTAssertGreaterThan(cases.count, 0, "\(suite) suite should have at least one case")
+        }
+    }
+
+    func test_caseFieldsDecoded() throws {
+        let cases = try loadConformanceCases(suite: "parser")
+        let errCase = try XCTUnwrap(cases.first(where: { $0.name == "test_parse_empty_response" }),
+            "Expected case 'test_parse_empty_response'")
+        XCTAssertEqual(errCase.action, "parse_full")
+        XCTAssertEqual(errCase.steps.count, 1)
+        let step = errCase.steps[0]
+        XCTAssertNotNil(step.expectError)
+        XCTAssertEqual(step.expectError?.category, "ParseError")
+    }
+
+    func test_streamingParserCaseHasSteps() throws {
+        let cases = try loadConformanceCases(suite: "streaming_parser")
+        let multiStep = try XCTUnwrap(cases.first(where: { $0.steps.count > 1 }),
+            "Expected a multi-step case in streaming_parser")
+        XCTAssertGreaterThan(multiStep.steps.count, 1,
+            "streaming_parser should have multi-step cases")
+    }
+
+    func test_catalogConfigDecoded() throws {
+        let cases = try loadConformanceCases(suite: "streaming_parser")
+        let caseWithCatalog = try XCTUnwrap(cases.first(where: { $0.catalog != nil }),
+            "Expected a case with catalog in streaming_parser")
+        let catalog = try XCTUnwrap(caseWithCatalog.catalog)
+        XCTAssertTrue(catalog.version == "0.8" || catalog.version == "0.9",
+            "Unexpected catalog version: \(catalog.version)")
+    }
+
+    func test_loadTestDataJSONWorks() throws {
+        // The streaming_parser suite references "test_data/simplified_s2c_v08.json"
+        let json = try loadTestDataJSON(path: "test_data/simplified_s2c_v08.json")
+        XCTAssertTrue(json is [String: Any] || json is [Any],
+            "Expected JSON object or array")
+    }
+}

--- a/Tests/A2UIConformanceTests/ConformanceHarness.swift
+++ b/Tests/A2UIConformanceTests/ConformanceHarness.swift
@@ -1,0 +1,237 @@
+// Tests/A2UIConformanceTests/ConformanceHarness.swift
+import Foundation
+import XCTest
+@testable import A2UISwiftCore
+
+// MARK: - Agent-only actions (XCTSkip these)
+
+private let agentOnlyActions: Set<String> = [
+    "generate_prompt", "select_catalog", "handle_rpc", "execute_tool",
+    "create_a2ui_part", "is_a2ui_part", "try_activate", "try_activate_extension",
+    "get_extension", "convert_event", "select_newest", "verify_cuttable_keys",
+    "render", "remove_strict_validation", "has_parts", "load_catalog",
+    "prune", "load"
+]
+
+func skipAgentOnlyAction(_ action: String, testName: String) throws {
+    if agentOnlyActions.contains(action) {
+        throw XCTSkip("N/A for renderer: action '\(action)' is agent-side only (test: \(testName))")
+    }
+}
+
+// MARK: - Error matching (mirrors Python _align_error_match)
+
+/// Transforms a YAML `message:` pattern into a regex that tolerates known phrasing
+/// differences between Python and Swift error messages.
+func alignErrorMatch(_ pattern: String) -> String {
+    if pattern.isEmpty { return pattern }
+    var p = pattern
+    if p.contains("required property") {
+        p = "(\(p)|Field required|missing value)"
+    }
+    if p.contains("'v0.9' was expected") {
+        p = "(\(p)|version must be)"
+    }
+    if p.contains("is not of type") {
+        p = "(\(p)|cannot convert|type mismatch)"
+    }
+    if p.contains("Validation failed") {
+        p = "(\(p)|Field required|Extra inputs)"
+    }
+    return p
+}
+
+func assertErrorMatches(_ error: Error, expected: ConformanceExpectedError, testName: String) {
+    let message = (error as? any A2uiError)?.message ?? error.localizedDescription
+    if let pattern = expected.message, !pattern.isEmpty {
+        let regex = alignErrorMatch(pattern)
+        let matched = (try? NSRegularExpression(pattern: regex, options: .caseInsensitive))
+            .map { $0.firstMatch(in: message, range: NSRange(message.startIndex..., in: message)) != nil }
+            ?? message.localizedCaseInsensitiveContains(pattern)
+        XCTAssertTrue(matched,
+            "[\(testName)] Error message '\(message)' did not match pattern '\(regex)'")
+    }
+}
+
+// MARK: - process_chunk dispatcher
+
+func runProcessChunk(testCase: ConformanceCase) async throws {
+    let parser = A2UIStreamParser()
+
+    // Buffer collects ParsedEvent values emitted between steps.
+    actor EventBuffer {
+        var events: [ParsedEvent] = []
+        func append(_ e: ParsedEvent) { events.append(e) }
+        func drain() -> [ParsedEvent] { let r = events; events = []; return r }
+    }
+    let buffer = EventBuffer()
+
+    let consumeTask = Task {
+        for await event in parser.events {
+            await buffer.append(event)
+        }
+    }
+
+    for step in testCase.steps {
+        guard let input = step.input else {
+            XCTFail("[\(testCase.name)] process_chunk step missing 'input'"); return
+        }
+
+        await parser.add(input)
+        // Sleep briefly to give the cooperative scheduler time to drain events reliably.
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let events = await buffer.drain()
+
+        if let expectedError = step.expectError {
+            let errorEvents = events.compactMap { e -> Error? in
+                if case .error(let err) = e { return err } else { return nil }
+            }
+            if let err = errorEvents.first {
+                assertErrorMatches(err, expected: expectedError, testName: testCase.name)
+            } else {
+                XCTFail("[\(testCase.name)] Expected error '\(expectedError.category)' but no error was emitted")
+            }
+            break
+        }
+
+        // Validate against step.expect.
+        if let expectedParts = step.expect as? [[String: Any]] {
+            // Non-empty expected array: verify we got corresponding events.
+            let nonErrorEvents = events.filter { if case .error = $0 { return false } else { return true } }
+            XCTAssertEqual(nonErrorEvents.count, expectedParts.count,
+                "[\(testCase.name)] Expected \(expectedParts.count) event(s), got \(nonErrorEvents.count)")
+            for (event, expected) in zip(nonErrorEvents, expectedParts) {
+                if let expectedText = expected["text"] as? String {
+                    if case .text(let actual) = event {
+                        XCTAssertEqual(
+                            actual.trimmingCharacters(in: .whitespacesAndNewlines),
+                            expectedText.trimmingCharacters(in: .whitespacesAndNewlines),
+                            "[\(testCase.name)] Text event mismatch")
+                    } else {
+                        XCTFail("[\(testCase.name)] Expected .text event but got \(event)")
+                    }
+                } else if expected["a2ui"] != nil {
+                    if case .message = event { /* ok */ } else {
+                        XCTFail("[\(testCase.name)] Expected .message event but got \(event)")
+                    }
+                }
+            }
+        } else if let arr = step.expect as? [Any], arr.isEmpty {
+            // Empty array means no events expected for this step.
+            let nonErrorEvents = events.filter { if case .error = $0 { return false } else { return true } }
+            XCTAssertTrue(nonErrorEvents.isEmpty,
+                "[\(testCase.name)] Expected no events but got \(nonErrorEvents.count)")
+        }
+        // nil expect → no assertion (step only feeds data, output verified by later steps).
+    }
+
+    await parser.finish()
+    await consumeTask.value
+}
+
+// MARK: - parse_full dispatcher
+
+func runParseFull(testCase: ConformanceCase) async throws {
+    for step in testCase.steps {
+        guard let input = step.input else {
+            XCTFail("[\(testCase.name)] parse_full step missing 'input'"); return
+        }
+
+        let results = await parseFullResponse(input)
+
+        if let expectedError = step.expectError {
+            XCTAssertFalse(results.errors.isEmpty,
+                "[\(testCase.name)] Expected error '\(expectedError.category)' but no error was emitted")
+            if let err = results.errors.first {
+                assertErrorMatches(err, expected: expectedError, testName: testCase.name)
+            }
+            return
+        }
+
+        if let expectedParts = step.expect as? [[String: Any]] {
+            let textParts = results.parts.filter { !$0.text.isEmpty }
+            XCTAssertEqual(textParts.count, expectedParts.count,
+                "[\(testCase.name)] Expected \(expectedParts.count) parts, got \(textParts.count)")
+            for (actual, expected) in zip(textParts, expectedParts) {
+                let expectedText = expected["text"] as? String ?? ""
+                XCTAssertEqual(actual.text.trimmingCharacters(in: .whitespacesAndNewlines),
+                               expectedText.trimmingCharacters(in: .whitespacesAndNewlines),
+                               "[\(testCase.name)] Text mismatch")
+            }
+        }
+    }
+}
+
+private struct ParseFullResult {
+    var parts: [(text: String, a2ui: Any?)] = []
+    var errors: [Error] = []
+}
+
+/// Wraps `A2UIStreamParser` for async full-response parsing.
+private func parseFullResponse(_ input: String) async -> ParseFullResult {
+    let parser = A2UIStreamParser()
+    var result = ParseFullResult()
+
+    let collectTask = Task {
+        var localResult = ParseFullResult()
+        for await event in parser.events {
+            switch event {
+            case .text(let t): localResult.parts.append((t, nil))
+            case .message(let m): localResult.parts.append(("", encodeMessageToAny(m)))
+            case .error(let e): localResult.errors.append(e)
+            }
+        }
+        return localResult
+    }
+
+    await parser.add(input)
+    await parser.finish()
+    result = await collectTask.value
+    return result
+}
+
+// MARK: - validate dispatcher
+
+func runValidate(testCase: ConformanceCase) throws {
+    // v0.8 validation is agent-SDK-layer only (uses A2uiValidator.validate which
+    // requires a full schema stack not present in the renderer); skip.
+    if testCase.catalog?.version == "0.8" {
+        throw XCTSkip("N/A for renderer: v0.8 validator cases require full schema stack (test: \(testCase.name))")
+    }
+    let decoder = JSONDecoder()
+    for step in testCase.steps {
+        guard let payload = step.payload else {
+            XCTFail("[\(testCase.name)] validate step missing 'payload'"); return
+        }
+
+        if let expectedError = step.expectError {
+            XCTAssertThrowsError(try validatePayload(payload, decoder: decoder),
+                "[\(testCase.name)] Expected error '\(expectedError.category)'") { err in
+                assertErrorMatches(err, expected: expectedError, testName: testCase.name)
+            }
+        } else {
+            XCTAssertNoThrow(try validatePayload(payload, decoder: decoder),
+                "[\(testCase.name)] Unexpected validation error")
+        }
+    }
+}
+
+private func validatePayload(_ payload: Any, decoder: JSONDecoder) throws {
+    guard let messages = payload as? [[String: Any]] else {
+        throw A2uiValidationError("Payload must be an array of message objects")
+    }
+    for msg in messages {
+        let data = try JSONSerialization.data(withJSONObject: msg)
+        _ = try decoder.decode(A2uiMessage.self, from: data)
+    }
+}
+
+// MARK: - Helpers
+
+private func encodeMessageToAny(_ message: A2uiMessage) -> Any {
+    guard let data = try? JSONEncoder().encode(message),
+          let obj = try? JSONSerialization.jsonObject(with: data) else {
+        return [String: Any]()
+    }
+    return obj
+}

--- a/Tests/A2UIConformanceTests/ConformanceHarnessTests.swift
+++ b/Tests/A2UIConformanceTests/ConformanceHarnessTests.swift
@@ -1,0 +1,105 @@
+// Tests/A2UIConformanceTests/ConformanceHarnessTests.swift
+import Foundation
+import XCTest
+@testable import A2UISwiftCore
+
+final class ConformanceHarnessTests: XCTestCase {
+
+    // MARK: - alignErrorMatch
+
+    func testAlignErrorMatchPassthrough() {
+        let pattern = "some other error"
+        XCTAssertEqual(alignErrorMatch(pattern), pattern)
+    }
+
+    func testAlignErrorMatchRequiredProperty() {
+        let result = alignErrorMatch("required property 'foo' missing")
+        XCTAssertTrue(result.contains("Field required"))
+        XCTAssertTrue(result.contains("missing value"))
+        XCTAssertTrue(result.contains("required property 'foo' missing"))
+    }
+
+    func testAlignErrorMatchVersionExpected() {
+        let result = alignErrorMatch("'v0.9' was expected")
+        XCTAssertTrue(result.contains("version must be"))
+        XCTAssertTrue(result.contains("'v0.9' was expected"))
+    }
+
+    func testAlignErrorMatchIsNotOfType() {
+        let result = alignErrorMatch("is not of type 'string'")
+        XCTAssertTrue(result.contains("cannot convert"))
+        XCTAssertTrue(result.contains("type mismatch"))
+        XCTAssertTrue(result.contains("is not of type 'string'"))
+    }
+
+    func testAlignErrorMatchValidationFailed() {
+        let result = alignErrorMatch("Validation failed for field")
+        XCTAssertTrue(result.contains("Field required"))
+        XCTAssertTrue(result.contains("Extra inputs"))
+        XCTAssertTrue(result.contains("Validation failed for field"))
+    }
+
+    func testAlignErrorMatchEmpty() {
+        XCTAssertEqual(alignErrorMatch(""), "")
+    }
+
+    // MARK: - skipAgentOnlyAction
+
+    func testSkipAgentOnlyActionThrowsForKnownActions() {
+        let agentActions = [
+            "generate_prompt", "select_catalog", "handle_rpc", "execute_tool",
+            "create_a2ui_part", "is_a2ui_part", "try_activate", "try_activate_extension",
+            "get_extension", "convert_event", "select_newest", "verify_cuttable_keys",
+            "render", "remove_strict_validation", "has_parts", "load_catalog",
+            "prune", "load"
+        ]
+        for action in agentActions {
+            XCTAssertThrowsError(
+                try skipAgentOnlyAction(action, testName: "test"),
+                "Expected error for agent-only action '\(action)'"
+            ) { err in
+                XCTAssertTrue(err is XCTSkip, "Expected XCTSkip for agent-only action '\(action)', got \(type(of: err))")
+            }
+        }
+    }
+
+    func testSkipAgentOnlyActionPassesForRendererActions() {
+        let rendererActions = ["process_chunk", "parse_full", "validate", "unknown_action"]
+        for action in rendererActions {
+            // Should not throw
+            do {
+                try skipAgentOnlyAction(action, testName: "test")
+            } catch {
+                XCTFail("skipAgentOnlyAction should not throw for renderer action '\(action)', got: \(error)")
+            }
+        }
+    }
+
+    // MARK: - runParseFull (basic smoke test)
+
+    func testParseFullPlainText() async {
+        let step = ConformanceStep(
+            input: "Hello world",
+            payload: nil,
+            args: nil,
+            expect: nil,
+            expectOutput: nil,
+            expectError: nil,
+            expectSelected: nil
+        )
+        let testCase = ConformanceCase(
+            name: "test_plain_text",
+            description: nil,
+            catalog: nil,
+            action: "parse_full",
+            steps: [step]
+        )
+        // Should not throw — plain text produces text events only
+        do {
+            try await runParseFull(testCase: testCase)
+        } catch {
+            XCTFail("runParseFull should not throw for plain text input, got: \(error)")
+        }
+    }
+
+}

--- a/Tests/A2UIConformanceTests/ParserConformanceTests.swift
+++ b/Tests/A2UIConformanceTests/ParserConformanceTests.swift
@@ -1,0 +1,27 @@
+// Tests/A2UIConformanceTests/ParserConformanceTests.swift
+import XCTest
+@testable import A2UISwiftCore
+
+final class ParserConformanceTests: XCTestCase {
+
+    private static var cases: [ConformanceCase] = {
+        (try? loadConformanceCases(suite: "parser")) ?? []
+    }()
+
+    func test_parser_conformance() async throws {
+        let cases = ParserConformanceTests.cases
+        guard !cases.isEmpty else {
+            throw XCTSkip("Could not load conformance cases for 'parser' — check Bundle.module resources")
+        }
+
+        for testCase in cases {
+            try skipAgentOnlyAction(testCase.action, testName: testCase.name)
+            switch testCase.action {
+            case "parse_full", "fix_payload":
+                try await runParseFull(testCase: testCase)
+            default:
+                throw XCTSkip("N/A for renderer: action '\(testCase.action)' (test: \(testCase.name))")
+            }
+        }
+    }
+}

--- a/Tests/A2UIConformanceTests/Resources/suites/catalog.yaml
+++ b/Tests/A2UIConformanceTests/Resources/suites/catalog.yaml
@@ -1,0 +1,477 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: test_with_pruning_components
+  description: Tests pruning components from the catalog schema.
+  catalog:
+    version: "0.8"
+    catalog_schema:
+      catalogId: basic
+      components:
+        Text: {type: object}
+        Button: {type: object}
+        Image: {type: object}
+  action: prune
+  args:
+    allowed_components: [Text, Button]
+  expect:
+    catalog_schema:
+      catalogId: basic
+      components:
+        Text: {type: object}
+        Button: {type: object}
+
+- name: test_with_pruning_components_v09
+  description: Tests pruning components and anyComponent oneOf in v0.9.
+  catalog:
+    version: "0.9"
+    catalog_schema:
+      catalogId: basic
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+            - $ref: "#/components/Button"
+            - $ref: "#/components/Image"
+      components:
+        Text: {}
+        Button: {}
+        Image: {}
+  action: prune
+  args:
+    allowed_components: [Text]
+  expect:
+    catalog_schema:
+      catalogId: basic
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+      components:
+        Text: {}
+
+- name: test_with_pruning_messages
+  description: Tests pruning messages from the S2C schema in v0.9.
+  catalog:
+    version: "0.9"
+    s2c_schema:
+      oneOf:
+        - $ref: "#/$defs/MessageA"
+        - $ref: "#/$defs/MessageB"
+        - $ref: "#/$defs/MessageC"
+      $defs:
+        MessageA: {type: object, properties: {a: {type: string}}}
+        MessageB: {type: object, properties: {b: {type: string}}}
+        MessageC: {type: object, properties: {c: {type: string}}}
+    catalog_schema: {catalogId: basic}
+  action: prune
+  args:
+    allowed_messages: [MessageA, MessageC]
+  expect:
+    s2c_schema:
+      oneOf:
+        - $ref: "#/$defs/MessageA"
+        - $ref: "#/$defs/MessageC"
+      $defs:
+        MessageA: {type: object, properties: {a: {type: string}}}
+        MessageC: {type: object, properties: {c: {type: string}}}
+
+- name: test_with_pruning_messages_internal_reachability
+  description: Tests that pruning preserves reachable types in S2C schema.
+  catalog:
+    version: "0.9"
+    s2c_schema:
+      oneOf:
+        - $ref: "#/$defs/MessageA"
+      $defs:
+        MessageA:
+          type: object
+          properties:
+            shared: {$ref: "#/$defs/SharedType"}
+        SharedType: {type: string}
+        UnusedType: {type: number}
+    catalog_schema: {catalogId: basic}
+  action: prune
+  args:
+    allowed_messages: [MessageA]
+  expect:
+    s2c_schema:
+      oneOf:
+        - $ref: "#/$defs/MessageA"
+      $defs:
+        MessageA:
+          type: object
+          properties:
+            shared: {$ref: "#/$defs/SharedType"}
+        SharedType: {type: string}
+
+- name: test_with_pruning_common_types
+  description: Tests that pruning components also prunes common types.
+  catalog:
+    version: "0.8"
+    common_types_schema:
+      $defs:
+        TypeForCompA: {type: string}
+        TypeForCompB: {type: number}
+    catalog_schema:
+      catalogId: basic
+      components:
+        CompA: {$ref: "common_types.json#/$defs/TypeForCompA"}
+        CompB: {$ref: "common_types.json#/$defs/TypeForCompB"}
+  action: prune
+  args:
+    allowed_components: [CompA]
+  expect:
+    common_types_schema:
+      $defs:
+        TypeForCompA: {type: string}
+
+- name: test_with_pruning_s2c_also_prunes_common_types
+  description: Tests that pruning messages also prunes common types.
+  catalog:
+    version: "0.9"
+    common_types_schema:
+      $defs:
+        TypeForA: {type: string}
+        TypeForB: {type: number}
+    s2c_schema:
+      oneOf:
+        - $ref: "#/$defs/MessageA"
+        - $ref: "#/$defs/MessageB"
+      $defs:
+        MessageA: {$ref: "common_types.json#/$defs/TypeForA"}
+        MessageB: {$ref: "common_types.json#/$defs/TypeForB"}
+    catalog_schema: {catalogId: basic}
+  action: prune
+  args:
+    allowed_messages: [MessageA]
+  expect:
+    common_types_schema:
+      $defs:
+        TypeForA: {type: string}
+
+- name: test_with_pruning_messages_v08
+  description: Tests pruning messages in v0.8 (properties instead of oneOf).
+  catalog:
+    version: "0.8"
+    s2c_schema:
+      properties:
+        beginRendering: {type: object}
+        surfaceUpdate: {type: object}
+        deleteSurface: {type: object}
+      required: [surfaceId]
+    catalog_schema: {catalogId: basic}
+  action: prune
+  args:
+    allowed_messages: [beginRendering, deleteSurface]
+  expect:
+    s2c_schema:
+      properties:
+        beginRendering: {type: object}
+        deleteSurface: {type: object}
+      required: [surfaceId]
+
+- name: test_render_as_llm_instructions
+  description: Tests rendering schemas as LLM instructions.
+  catalog:
+    version: "0.9"
+    s2c_schema: {s2c: schema}
+    common_types_schema: {$defs: {common: types}}
+    catalog_schema:
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      catalog: schema
+      catalogId: id_basic
+  action: render
+  expect_output: |
+    ---BEGIN A2UI JSON SCHEMA---
+
+    ### Server To Client Schema:
+    {"s2c":"schema"}
+
+    ### Common Types Schema:
+    {"$defs":{"common":"types"}}
+
+    ### Catalog Schema:
+    {"$schema":"https://json-schema.org/draft/2020-12/schema","catalog":"schema","catalogId":"id_basic"}
+
+    ---END A2UI JSON SCHEMA---
+
+- name: test_render_as_llm_instructions_drops_empty_common_types
+  description: Tests that empty common types are omitted in rendering.
+  catalog:
+    version: "0.9"
+    s2c_schema: {s2c: schema}
+    common_types_schema: {}
+    catalog_schema:
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      catalog: schema
+      catalogId: id_basic
+  action: render
+  expect_output: |
+    ---BEGIN A2UI JSON SCHEMA---
+
+    ### Server To Client Schema:
+    {"s2c":"schema"}
+
+    ### Catalog Schema:
+    {"$schema":"https://json-schema.org/draft/2020-12/schema","catalog":"schema","catalogId":"id_basic"}
+
+    ---END A2UI JSON SCHEMA---
+
+- name: test_load_examples
+  description: Tests loading examples from a directory.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/basic"
+  expect_output: |
+    ---BEGIN example1---
+    [{"beginRendering": {"surfaceId": "id"}}]
+    ---END example1---
+
+    ---BEGIN example2---
+    [{"beginRendering": {"surfaceId": "id"}}]
+    ---END example2---
+
+- name: test_load_examples_validation_fails_on_bad_json
+  description: Tests that loading fails on bad JSON when validate is true.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/bad_json"
+    validate: true
+  expect_error:
+    category: "CatalogError"
+    message: "Failed to validate example"
+
+- name: test_load_examples_validation_fails_on_schema_error
+  description: Tests that loading fails on schema error when validate is true.
+  catalog:
+    version: "0.8"
+    s2c_schema:
+      type: object
+      properties: {myKey: {type: integer}}
+      required: [myKey]
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/schema_error"
+    validate: true
+  expect_error:
+    category: "CatalogError"
+    message: "Failed to validate example"
+
+- name: test_load_examples_with_glob
+  description: Tests loading examples with glob patterns.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/glob_recursive/**/*.json"
+  expect_output: |
+    ---BEGIN deep---
+    [{"beginRendering": {"surfaceId": "deep"}}]
+    ---END deep---
+
+    ---BEGIN top---
+    [{"beginRendering": {"surfaceId": "top"}}]
+    ---END top---
+
+- name: test_load_examples_with_glob_filter
+  description: Tests filtering examples with glob prefix.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/glob_filter/user_*.json"
+  expect_output: |
+    ---BEGIN user_profile---
+    [{"beginRendering": {"surfaceId": "user"}}]
+    ---END user_profile---
+
+    ---BEGIN user_settings---
+    [{"beginRendering": {"surfaceId": "settings"}}]
+    ---END user_settings---
+
+- name: test_load_examples_with_glob_range
+  description: Tests character range in glob.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/glob_range/step[1-2].json"
+  expect_output: |
+    ---BEGIN step1---
+    [{"beginRendering": {"surfaceId": "1"}}]
+    ---END step1---
+
+    ---BEGIN step2---
+    [{"beginRendering": {"surfaceId": "2"}}]
+    ---END step2---
+
+- name: test_load_examples_with_glob_negation
+  description: Tests negation in glob.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "test_data/load_examples/glob_negation/[!i]*.json"
+  expect_output: |
+    ---BEGIN visible---
+    [{"beginRendering": {"surfaceId": "visible"}}]
+    ---END visible---
+
+- name: test_load_examples_none
+  description: Tests that loading with None path returns empty string.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: null
+  expect_output: ""
+
+- name: test_load_examples_non_existent_path
+  description: Tests that loading with non-existent path returns empty string.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: load
+  args:
+    path: "/non/existent/path"
+  expect_output: ""
+
+- name: test_remove_strict_validation
+  description: Tests the remove_strict_validation modifier.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: remove_strict_validation
+  args:
+    schema:
+      type: object
+      properties:
+        a: {type: string, additionalProperties: false}
+        b:
+          type: array
+          items: {type: object, additionalProperties: false}
+      additionalProperties: false
+  expect:
+    schema:
+      type: object
+      properties:
+        a: {type: string}
+        b:
+          type: array
+          items: {type: object}
+
+- name: test_remove_strict_validation_keeps_true
+  description: Tests that remove_strict_validation keeps additionalProperties true.
+  catalog:
+    version: "0.8"
+    catalog_schema: {catalogId: basic}
+  action: remove_strict_validation
+  args:
+    schema: {type: object, additionalProperties: true}
+  expect:
+    schema: {type: object, additionalProperties: true}
+
+- name: test_with_pruning_common_types_transitive
+  description: Tests that pruning components preserves transitively reachable common types.
+  catalog:
+    version: "0.9"
+    common_types_schema:
+      $defs:
+        TypeForCompA:
+          type: string
+          $ref: "#/$defs/SubtypeForA"
+        TypeForCompB: {type: number}
+        SubtypeForA: {type: boolean}
+    catalog_schema:
+      catalogId: basic
+      components:
+        CompA: {$ref: "common_types.json#/$defs/TypeForCompA"}
+        CompB: {$ref: "common_types.json#/$defs/TypeForCompB"}
+  action: prune
+  args:
+    allowed_components: [CompA]
+  expect:
+    common_types_schema:
+      $defs:
+        TypeForCompA:
+          type: string
+          $ref: "#/$defs/SubtypeForA"
+        SubtypeForA: {type: boolean}
+
+- name: test_render_as_llm_instructions_drops_common_types_no_defs
+  description: Tests that common types without $defs are omitted in rendering.
+  catalog:
+    version: "0.9"
+    s2c_schema: {s2c: schema}
+    common_types_schema: {something: else}
+    catalog_schema:
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      catalog: schema
+      catalogId: id_basic
+  action: render
+  expect_output: |
+    ---BEGIN A2UI JSON SCHEMA---
+
+    ### Server To Client Schema:
+    {"s2c":"schema"}
+
+    ### Catalog Schema:
+    {"$schema":"https://json-schema.org/draft/2020-12/schema","catalog":"schema","catalogId":"id_basic"}
+
+    ---END A2UI JSON SCHEMA---
+
+- name: test_render_as_llm_instructions_drops_common_types_empty_defs
+  description: Tests that common types with empty $defs are omitted in rendering.
+  catalog:
+    version: "0.9"
+    s2c_schema: {s2c: schema}
+    common_types_schema: {$defs: {}}
+    catalog_schema:
+      $schema: "https://json-schema.org/draft/2020-12/schema"
+      catalog: schema
+      catalogId: id_basic
+  action: render
+  expect_output: |
+    ---BEGIN A2UI JSON SCHEMA---
+
+    ### Server To Client Schema:
+    {"s2c":"schema"}
+
+    ### Catalog Schema:
+    {"$schema":"https://json-schema.org/draft/2020-12/schema","catalog":"schema","catalogId":"id_basic"}
+
+    ---END A2UI JSON SCHEMA---
+
+- name: test_custom_cuttable_keys
+  description: Tests that custom cuttable_keys are preserved in A2uiCatalog.
+  catalog:
+    version: "0.9"
+    custom_cuttable_keys: ["customKey1", "customKey2"]
+    catalog_schema: {catalogId: basic}
+  action: verify_cuttable_keys
+  expect:
+    custom_cuttable_keys: ["customKey1", "customKey2"]

--- a/Tests/A2UIConformanceTests/Resources/suites/parser.yaml
+++ b/Tests/A2UIConformanceTests/Resources/suites/parser.yaml
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: test_parse_empty_response
+  description: Tests that empty response raises error.
+  action: parse_full
+  input: ""
+  expect_error:
+    category: "ParseError"
+    message: "not found in response"
+
+- name: test_parse_response_only_text_no_tags
+  description: Tests that response without tags raises error.
+  action: parse_full
+  input: "Only text, no tags."
+  expect_error:
+    category: "ParseError"
+    message: "not found in response"
+
+- name: test_parse_response_empty_tags
+  description: Tests that empty tags raise error.
+  action: parse_full
+  input: "<a2ui-json></a2ui-json>"
+  expect_error:
+    category: "ParseError"
+    message: "A2UI JSON part is empty"
+
+- name: test_parse_response_only_json_with_tags
+  description: Tests parsing only JSON with tags.
+  action: parse_full
+  input: '<a2ui-json>[{"id": "test"}]</a2ui-json>'
+  expect:
+    - text: ""
+      a2ui: [{"id": "test"}]
+
+- name: test_parse_response_with_text_and_tags
+  description: Tests parsing response with text before tags.
+  action: parse_full
+  input: "Hello\n<a2ui-json>[{\"id\": \"test\"}]</a2ui-json>"
+  expect:
+    - text: "Hello"
+      a2ui: [{"id": "test"}]
+
+- name: test_parse_response_with_trailing_text
+  description: Tests parsing response with trailing text.
+  action: parse_full
+  input: "Hello\n<a2ui-json>[{\"id\": \"test\"}]</a2ui-json>\nGoodbye"
+  expect:
+    - text: "Hello"
+      a2ui: [{"id": "test"}]
+    - text: "Goodbye"
+
+- name: test_parse_response_multiple_blocks
+  description: Tests parsing multiple blocks.
+  action: parse_full
+  input: "Part 1\n<a2ui-json>\n[{\"id\": \"1\"}]\n</a2ui-json>\nPart 2\n<a2ui-json>\n[{\"id\": \"2\"}]\n</a2ui-json>\nPart 3"
+  expect:
+    - text: "Part 1"
+      a2ui: [{"id": "1"}]
+    - text: "Part 2"
+      a2ui: [{"id": "2"}]
+    - text: "Part 3"
+
+- name: test_parse_response_with_markdown_blocks
+  description: Tests stripping markdown code blocks inside tags.
+  action: parse_full
+  input: "Text\n<a2ui-json>\n```json\n[{\"id\": \"test\"}]\n```\n</a2ui-json>"
+  expect:
+    - text: "Text"
+      a2ui: [{"id": "test"}]
+
+- name: test_parse_response_invalid_json
+  description: Tests that invalid JSON raises error.
+  action: parse_full
+  input: "<a2ui-json>\ninvalid_json\n</a2ui-json>"
+  expect_error:
+    category: "ParseError"
+    message: "Failed to parse"
+
+- name: test_fix_payload_trailing_comma_list
+  description: Tests removing trailing comma in list.
+  action: fix_payload
+  input: '[{"type": "Text", "text": "Hello"},]'
+  expect: [{"type": "Text", "text": "Hello"}]
+
+- name: test_fix_payload_trailing_comma_object
+  description: Tests removing trailing comma in object.
+  action: fix_payload
+  input: '{"type": "Text", "text": "Hello",}'
+  expect: [{"type": "Text", "text": "Hello"}]
+
+- name: test_fix_payload_auto_wrap
+  description: Tests auto-wrapping single object in list.
+  action: fix_payload
+  input: '{"type": "Text", "text": "Hello"}'
+  expect: [{"type": "Text", "text": "Hello"}]
+
+- name: test_fix_payload_smart_quotes
+  description: Tests normalizing smart quotes.
+  action: fix_payload
+  input: '{"type": “Text”, "other": "Value’s"}'
+  expect: [{"type": "Text", "other": "Value's"}]
+
+- name: test_has_a2ui_parts_true
+  description: Tests that has_a2ui_parts returns true when tags are present.
+  action: has_parts
+  input: "Hello <a2ui-json>[]</a2ui-json> World"
+  expect: true
+
+- name: test_has_a2ui_parts_false_no_tags
+  description: Tests that has_a2ui_parts returns false when no tags are present.
+  action: has_parts
+  input: "Hello World"
+  expect: false
+
+- name: test_has_a2ui_parts_false_only_open
+  description: Tests that has_a2ui_parts returns false when only open tag is present.
+  action: has_parts
+  input: "Hello <a2ui-json> World"
+  expect: false
+
+- name: test_fix_payload_commas_in_strings
+  description: "Tests that commas in strings are not removed."
+  action: fix_payload
+  input: '{"text": "Hello, world", "array": ["a,b", "c"]}'
+  expect: [{"text": "Hello, world", "array": ["a,b", "c"]}]
+
+- name: test_fix_payload_trailing_comma_nested_object
+  description: Tests removing trailing comma in a nested object.
+  action: fix_payload
+  input: '{"a": {"b": 1,}}'
+  expect: [{"a": {"b": 1}}]
+
+- name: test_fix_payload_trailing_comma_nested_array
+  description: Tests removing trailing comma in a nested array.
+  action: fix_payload
+  input: '[{"a": [1, 2, 3,]}]'
+  expect: [{"a": [1, 2, 3]}]

--- a/Tests/A2UIConformanceTests/Resources/suites/schema_manager.yaml
+++ b/Tests/A2UIConformanceTests/Resources/suites/schema_manager.yaml
@@ -1,0 +1,328 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- Catalog Selection Tests ---
+
+- name: test_select_catalog_default
+  description: If supported_catalog_ids is not provided, return the first supported catalog.
+  action: select_catalog
+  args:
+    supported_catalogs:
+      - catalogId: id_basic
+        components: {}
+      - catalogId: id_custom1
+        components: {}
+      - catalogId: id_custom2
+        components: {}
+    client_capabilities: {}
+  expect_selected: id_basic
+
+- name: test_select_catalog_intersection
+  description: Find the intersection, return any catalog that matches.
+  action: select_catalog
+  args:
+    supported_catalogs:
+      - catalogId: id_basic
+        components: {}
+      - catalogId: id_custom1
+        components: {}
+      - catalogId: id_custom2
+        components: {}
+    client_capabilities:
+      supportedCatalogIds: ["id_custom2", "id_custom1"]
+  expect_selected: id_custom2
+
+- name: test_select_catalog_priority
+  description: Priority is determined by the order in supported_catalog_ids.
+  action: select_catalog
+  args:
+    supported_catalogs:
+      - catalogId: id_basic
+        components: {}
+      - catalogId: id_custom1
+        components: {}
+      - catalogId: id_custom2
+        components: {}
+    client_capabilities:
+      supportedCatalogIds: ["id_custom1", "id_custom2"]
+  expect_selected: id_custom1
+
+- name: test_select_catalog_no_match
+  description: Raise error if supported list is non-empty but no match exists.
+  action: select_catalog
+  args:
+    supported_catalogs:
+      - catalogId: id_basic
+        components: {}
+      - catalogId: id_custom1
+        components: {}
+    client_capabilities:
+      supportedCatalogIds: ["id_not_exists"]
+  expect_error:
+    category: "CatalogError"
+    message: "No client-supported catalog found"
+
+- name: test_select_catalog_inline
+  description: Inline catalog loading (merges onto base).
+  action: select_catalog
+  args:
+    accepts_inline_catalogs: true
+    supported_catalogs:
+      - catalogId: id_basic
+        components:
+          Text: {}
+    client_capabilities:
+      inlineCatalogs:
+        - catalogId: id_inline
+          components:
+            Button: {}
+  expect_catalog_schema:
+    catalogId: id_basic
+    components:
+      Text: {}
+      Button: {}
+
+- name: test_select_catalog_inline_not_accepted
+  description: Inline catalog loading should fail if not accepted.
+  action: select_catalog
+  args:
+    accepts_inline_catalogs: false
+    supported_catalogs:
+      - catalogId: id_basic
+    client_capabilities:
+      inlineCatalogs:
+        - catalogId: id_inline
+  expect_error:
+    category: "CatalogError"
+    message: "the agent does not accept inline catalogs"
+
+- name: test_select_catalog_multiple_inline
+  description: Tests that multiple inline catalogs are merged.
+  action: select_catalog
+  args:
+    accepts_inline_catalogs: true
+    supported_catalogs:
+      - catalogId: id_basic
+        components:
+          Text: {}
+    client_capabilities:
+      inlineCatalogs:
+        - catalogId: id_basic
+          components:
+            Button: {}
+        - catalogId: id_basic
+          components:
+            Icon: {}
+  expect_catalog_schema:
+    catalogId: id_basic
+    components:
+      Text: {}
+      Button: {}
+      Icon: {}
+
+- name: test_select_catalog_no_match_with_inline
+  description: Fallback to default catalog when no match in supported list but inline is present.
+  action: select_catalog
+  args:
+    accepts_inline_catalogs: true
+    supported_catalogs:
+      - catalogId: id_basic
+        components:
+          Text: {}
+      - catalogId: id_custom1
+        components: {}
+    client_capabilities:
+      supportedCatalogIds: ["id_not_exists"]
+      inlineCatalogs:
+        - catalogId: id_basic
+          components:
+            Button: {}
+  expect_catalog_schema:
+    catalogId: id_basic
+    components:
+      Text: {}
+      Button: {}
+
+# --- Manager Modifier Tests ---
+
+- name: test_manager_with_modifiers
+  description: Tests that A2uiSchemaManager applies modifiers during loading.
+  catalog_configs:
+    - name: test_strict
+      path: "test_data/load_examples/schema_with_strict/catalog.json"
+  modifiers: ["remove_strict_validation"]
+  action: load_catalog
+  expect:
+    catalog_schema:
+      catalogId: "test_strict"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+
+- name: test_manager_no_modifiers
+  description: Tests that A2uiSchemaManager works fine without modifiers.
+  catalog_configs:
+    - name: test_strict
+      path: "test_data/load_examples/schema_with_strict/catalog.json"
+  action: load_catalog
+  expect:
+    catalog_schema:
+      catalogId: "test_strict"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+          additionalProperties: false
+
+# --- Prompt Generation Tests ---
+
+- name: test_generate_system_prompt_minimal
+  description: Tests prompt generation with minimal arguments.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Just Role"
+  expect_contains:
+    - "Just Role"
+    - "## Workflow Description:"
+    - "The generated response MUST follow these rules:"
+
+- name: test_generate_system_prompt_custom_workflow
+  description: Tests appending custom workflow rules.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Role"
+    workflow_description: "Custom Rule Content"
+  expect_contains:
+    - "Role"
+    - "## Workflow Description:"
+    - "The generated response MUST follow these rules:"
+    - "Custom Rule Content"
+
+- name: test_generate_system_prompt_full
+  description: Tests full prompt generation with all descriptions.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Role"
+    workflow_description: "Workflow"
+    ui_description: "Render UI."
+  expect_contains:
+    - "Role"
+    - "## Workflow Description:"
+    - "Workflow"
+    - "## UI Description:"
+    - "Render UI."
+
+- name: test_generate_system_prompt_with_schema
+  description: Tests prompt generation with schema included.
+  action: generate_prompt
+  args:
+    version: "0.9"
+    role_description: "Role"
+    include_schema: true
+  expect_contains:
+    - "Role"
+    - "---BEGIN A2UI JSON SCHEMA---"
+    - "### Server To Client Schema:"
+    - "### Catalog Schema:"
+    - "---END A2UI JSON SCHEMA---"
+
+- name: test_generate_system_prompt_with_examples
+  description: Tests prompt generation with examples included.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Role"
+    include_examples: true
+    examples_path: "test_data/load_examples/basic"
+  expect_contains:
+    - "Role"
+    - "### Examples:"
+    - "---BEGIN example1---"
+    - "---END example1---"
+    - "---BEGIN example2---"
+    - "---END example2---"
+
+- name: test_generate_system_prompt_with_inline_catalog
+  description: Tests inline catalog handling in prompt generation.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Role"
+    include_schema: true
+    accepts_inline_catalogs: true
+    client_ui_capabilities:
+      inlineCatalogs:
+        - catalogId: id_inline
+          components:
+            Button: {}
+  expect_contains:
+    - "Role"
+    - "---BEGIN A2UI JSON SCHEMA---"
+    - "### Server To Client Schema:"
+    - "### Catalog Schema:"
+    - '"Button": {}'
+    - "---END A2UI JSON SCHEMA---"
+
+# --- New Tests requested by User ---
+
+- name: test_schema_manager_init_custom_catalog
+  description: Tests that A2uiSchemaManager can load a custom catalog from path.
+  action: load_catalog
+  catalog_configs:
+    - name: standard
+      path: "test_data/schema_manager/catalog.json"
+    - name: Custom
+      path: "test_data/schema_manager/custom_catalog.json"
+  expect:
+    supported_catalog_ids: ["basic", "Custom"]
+
+- name: test_generate_system_prompt_v0_9_common_types
+  description: Tests v0.9 prompt generation with common types included.
+  action: generate_prompt
+  args:
+    version: "0.9"
+    role_description: "Role"
+    include_schema: true
+  expect_contains:
+    - "Role"
+    - "---BEGIN A2UI JSON SCHEMA---"
+    - "### Server To Client Schema:"
+    - "### Common Types Schema:"
+    - "### Catalog Schema:"
+    - "---END A2UI JSON SCHEMA---"
+
+- name: test_generate_system_prompt_full_with_caps
+  description: Tests full prompt generation with capabilities and allowed components.
+  action: generate_prompt
+  args:
+    version: "0.8"
+    role_description: "Role"
+    include_schema: true
+    client_ui_capabilities:
+      supportedCatalogIds: ["https://a2ui.org/specification/v0_8/standard_catalog_definition.json"]
+
+    allowed_components: ["Text"]
+  expect_contains:
+    - "Role"
+    - "---BEGIN A2UI JSON SCHEMA---"
+    - "### Server To Client Schema:"
+    - "### Catalog Schema:"
+    - '"Text": {'
+    - "---END A2UI JSON SCHEMA---"

--- a/Tests/A2UIConformanceTests/Resources/suites/streaming_parser.yaml
+++ b/Tests/A2UIConformanceTests/Resources/suites/streaming_parser.yaml
@@ -1,0 +1,3041 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: test_incremental_yielding
+  description: Tests that partial chunks are buffered and yielded correctly.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: process_chunk
+  steps:
+    - input: "Here is your"
+      expect: [{text: "Here is your"}]
+    - input: " response.<a2ui-json>["
+      expect: [{text: " response."}]
+    - input: '{"beginRendering": {"surfaceId": "s1", "root": "root-column"}},'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "root-column"}}]}]
+
+- name: test_waiting_for_root_component
+  description: Tests that components are not yielded until reachable from root.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          additionalProperties: true
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+            children:
+              type: array
+              items: {type: string, title: "ComponentId"}
+          additionalProperties: true
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"Text": {"text": {"literalString": "hello"}}}}'
+      expect: []
+    - input: ', {"id": "root", "component": {"Card": {"child": "c1"}}}]}</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component:
+                      Text:
+                        text:
+                          literalString: "hello"
+                  - id: "root"
+                    component:
+                      Card:
+                        child: "c1"
+
+- name: test_complete_surface_ignore_orphan_component
+  description: Tests that orphan components (not reachable from root) are ignored.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          additionalProperties: true
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": "root"}}}, {"id": "orphan", "component": {"Text": {"text": "orphan"}}}]}}] </a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: "root"
+
+- name: test_circular_reference_detection
+  description: Tests that circular references are detected during streaming.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "c1", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "c1", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"Card": {"child": "c2"}}}]}},{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c2", "component": {"Card": {"child": "c1"}}}]}}]}} </a2ui-json>'
+      expect_error:
+        category: "RecursionError"
+        message: "Circular reference detected"
+
+- name: test_self_reference_detection
+  description: Tests that self-references are detected during streaming.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "c1", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "c1", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"Card": {"child": "c1"}}}]}}]}} </a2ui-json>'
+      expect_error:
+        category: "RecursionError"
+        message: "Self-reference detected"
+
+- name: test_interleaved_conversational_text
+  description: Tests that conversational text and A2UI content are interleaved correctly.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: "Hello! "
+      expect: [{text: "Hello! "}]
+    - input: "Here is your UI: <a2ui-json>"
+      expect: [{text: "Here is your UI: "}]
+    - input: '[{"beginRendering": {"root": "root", "surfaceId": "s1"}}]'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: "</a2ui-json> That's all!"
+      expect: [{text: " That's all!"}]
+
+- name: test_split_tag_handling_for_text
+  description: Tests that the parser handles the opening tag split across chunks correctly.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: "Talking <a2u"
+      expect: [{text: "Talking "}]
+    - input: "i-json>"
+      expect: []
+    - input: '[{"beginRendering": {"root": "r", "surfaceId": "s"}}] </a2ui-json> End.'
+      expect:
+        - a2ui: [{beginRendering: {root: "r", surfaceId: "s"}}]
+        - text: " End."
+
+- name: test_only_begin_rendering
+  description: Tests that beginRendering is yielded only when complete.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>"
+      expect: []
+    - input: "["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1", "styles": {"primaryColor": "#FF0000",'
+      expect: []
+    - input: '"font": "Roboto"}'
+      expect: []
+    - input: "}"
+      expect: []
+    - input: "}"
+      expect:
+        [
+          {
+            a2ui:
+              [
+                {
+                  beginRendering:
+                    {
+                      root: "root",
+                      surfaceId: "s1",
+                      styles: {primaryColor: "#FF0000", font: "Roboto"},
+                    },
+                },
+              ],
+          },
+        ]
+
+- name: test_multiple_a2ui_blocks
+  description: Tests that multiple A2UI blocks are handled correctly with interleaved text.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: test_catalog
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: process_chunk
+  steps:
+    - input: 'Some text here <a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}}] </a2ui-json> mid text'
+      expect:
+        - text: "Some text here "
+          a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]
+        - text: " mid text"
+    - input: ' more text <a2ui-json>[{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": "block2"}}}]}}] </a2ui-json> trailing text'
+      expect:
+        - text: " more text "
+          a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: "block2"
+        - text: " trailing text"
+
+- name: test_partial_json_and_incremental_yielding
+  description: Tests that partial JSON chunks are fixed and yielded incrementally.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": "hello'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: "hello"
+
+- name: test_partial_single_child_string
+  description: Tests that placeholders are yielded for missing children and resolved when they arrive.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+        Row:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList: {type: array}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Card": {"child": "c1"}}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Card:
+                        child: "loading_c1"
+                  - id: "loading_c1"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+    - input: '{"id": "c1", "component": {"Text": {"text": "child 1"}}}]}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component:
+                      Text:
+                        text: "child 1"
+                  - id: "root"
+                    component:
+                      Card:
+                        child: "c1"
+
+- name: test_partial_template_componentId
+  description: Tests that placeholders are yielded for missing template components and resolved when they arrive.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+        List:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                template:
+                  type: object
+                  properties:
+                    componentId: {type: string, title: "ComponentId"}
+        Row:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList: {type: array}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"List": {"children": {"template": {"componentId": "c1"}}}}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      List:
+                        children: {template: {componentId: "loading_c1"}}
+                  - id: "loading_c1"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+    - input: '{"id": "c1", "component": {"Text": {"text": "child 1"}}}]}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component:
+                      Text:
+                        text: "child 1"
+                  - id: "root"
+                    component:
+                      List:
+                        children: {template: {componentId: "c1"}}
+
+- name: test_partial_children_lists
+  description: Tests that placeholders are yielded for all missing children in a list and resolved individually.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+        Container:
+          type: object
+          properties:
+            children:
+              type: array
+              items: {type: string, title: "ComponentId"}
+        Row:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList: {type: array}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Container": {"children": ["c1", "c2", "c3"]}}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Container:
+                        children: ["loading_c1", "loading_c2", "loading_c3"]
+                  - id: "loading_c1"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+                  - id: "loading_c2"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+                  - id: "loading_c3"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+    - input: '{"id": "c1", "component": {"Text": {"text": "child 1"}}}]}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component:
+                      Text:
+                        text: "child 1"
+                  - id: "root"
+                    component:
+                      Container:
+                        children: ["c1", "loading_c2", "loading_c3"]
+                  - id: "loading_c2"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+                  - id: "loading_c3"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+
+- name: test_data_model_before_components
+  description: Tests that data model updates can be processed before components.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"dataModelUpdate": {"surfaceId": "s1", "contents": [{"key": "name", "valueString": "Alice"}]}, '
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "s1"
+                contents: [{key: "name", valueString: "Alice"}]
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"path": "/name"}}}}}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {path: "/name"}
+
+- name: test_data_model_after_components
+  description: Tests that components can be processed before data model updates.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"path": "/name"}}}}}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {path: "/name"}
+    - input: '{"dataModelUpdate": {"surfaceId": "s1", "contents": [{"key": "name", "valueString": "Alice"}]}}</a2ui-json>'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "s1"
+                contents: [{key: "name", valueString: "Alice"}]
+
+- name: test_partial_paths
+  description: Tests that partial paths are buffered and not yielded until complete.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"path": "/loca'
+      expect: []
+    - input: 'tion"}}}}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {path: "/location"}
+    - input: "]}]</a2ui-json>"
+      expect: []
+
+- name: test_url_placeholders_with_hints
+  description: "Verifies that properties hinting at being images or links get specialized placeholders (Note: Python test actually expects full resolution as all components are provided in the chunk)."
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Container:
+          type: object
+          properties:
+            children:
+              type: array
+              items: {type: string, title: "ComponentId"}
+            imageUrl:
+              type: object
+              properties:
+                path: {type: string}
+        Card:
+          type: object
+          properties:
+            href:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Container": {"children": ["img-comp", "link-comp"]}}},{"id": "img-comp", "component": {"Container": {"imageUrl": {"path": "/heroImage"}}}},{"id": "link-comp", "component": {"Card": {"href": {"path": "/docs"}}}}]}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "img-comp"
+                    component:
+                      Container:
+                        imageUrl: {path: "/heroImage"}
+                  - id: "link-comp"
+                    component:
+                      Card:
+                        href: {path: "/docs"}
+                  - id: "root"
+                    component:
+                      Container:
+                        children: ["img-comp", "link-comp"]
+    - input: "]}]</a2ui-json>"
+      expect: []
+
+- name: test_cut_atomic_id
+  description: Tests that atomic keys are buffered and not yielded until complete.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "contact'
+      expect: []
+    - input: '-card"}}, {"surfaceUpdate": {"surfaceId": "contact-card", "components": [{"id": "button'
+      expect:
+        - a2ui: [{beginRendering: {root: "root", surfaceId: "contact-card"}}]
+    - input: '-text"'
+      expect: []
+    - input: ', "component": {"Text": {"text": "hi"}}}, {"id": "root", "component": {"Card": {"child": "button-text"}}}]}}</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "contact-card"
+                components:
+                  - id: "button-text"
+                    component: {Text: {text: "hi"}}
+                  - id: "root"
+                    component: {Card: {child: "button-text"}}
+
+- name: test_cut_cuttable_text
+  description: Tests that cuttable text is yielded eagerly even if cut.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                literalString: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"literalString": "Em'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {literalString: "Em"}
+    - input: 'ail"}}}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {literalString: "Email"}
+
+- name: test_message_ordering_buffering
+  description: Tests that surfaceUpdate is buffered until beginRendering arrives.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": "hi"}}}]}}, '
+      expect: []
+    - input: '{"beginRendering": {"surfaceId": "s1", "root": "root"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - beginRendering: {surfaceId: "s1", root: "root"}
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components: [{id: "root", component: {Text: {text: "hi"}}}]
+
+- name: test_delete_surface_buffering
+  description: Tests that deleteSurface before beginRendering is ignored.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"deleteSurface": {"surfaceId": "s1"}}, '
+      expect: []
+    - input: '{"beginRendering": {"surfaceId": "s1", "root": "root"}}]'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "root"}}]}]
+
+- name: test_cut_path
+  description: Tests that non-cuttable keys like path are not yielded until complete.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"path": "/user'
+      expect: []
+    - input: '/profile"}}}}]}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components: [{id: "root", component: {Text: {text: {path: "/user/profile"}}}}]
+
+- name: test_strict_begin_rendering_validation
+  description: Tests that invalid messages fail validation.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"unknownMessage": "invalid"}]'
+      expect_error: "Validation failed"
+
+- name: test_yield_validation_failure
+  description: Tests that invalid components fail validation.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          required: ["text"]
+          properties:
+            text: {type: string}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"surfaceId": "s1", "root": "root"}}, '
+      expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "root"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {}}}]}}]'
+      expect_error: "Validation failed"
+
+- name: test_delta_streaming_correctness
+  description: Verifies that the parser correctly assembles components from small deltas.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                literalString: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>"
+      expect: []
+    - input: "["
+      expect: []
+    - input: '{"beginRendering": {"surfaceId": "s1", "root": "r1'
+      expect: []
+    - input: '"'
+      expect: []
+    - input: "}"
+      expect: []
+    - input: "}"
+      expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "r1"}}]}]
+    - input: ', {"surfaceUpdate": {"surfaceId": "s1", "components": ['
+      expect: []
+    - input: '{"id": "r1", "compon'
+      expect: []
+    - input: 'ent": {"Text": {"text": {"literalString": "hello'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components: [{id: "r1", component: {Text: {text: {literalString: "hello"}}}}]
+    - input: " world"
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components: [{id: "r1", component: {Text: {text: {literalString: "hello world"}}}}]
+
+- name: test_multiple_re_yielding_scenarios
+  description: Tests multiple re-yielding scenarios with data model updates.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+        Container:
+          type: object
+          properties:
+            children:
+              type: array
+              items: {type: string, title: "ComponentId"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "root", "surfaceId": "s1"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Container": {"children": ["c1", "c2"]}}}, {"id": "c1", "component": {"Text": {"text": {"path": "/p1"}}}}, {"id": "c2", "component": {"Text": {"text": {"path": "/p2"}}}}]}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: {Text: {text: {path: "/p1"}}}
+                  - id: "c2"
+                    component: {Text: {text: {path: "/p2"}}}
+                  - id: "root"
+                    component: {Container: {children: ["c1", "c2"]}}
+    - input: '{"dataModelUpdate": {"surfaceId": "s1", "contents": [{"key": "p1", "valueString": "v1"}]}, '
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "s1"
+                contents: [{key: "p1", valueString: "v1"}]
+    - input: '{"dataModelUpdate": {"surfaceId": "s1", "contents": [{"key": "p2", "valueString": "v2"}]}}'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "s1"
+                contents: [{key: "p2", valueString: "v2"}]
+
+- name: test_incremental_data_model_streaming
+  description: Verifies that the parser yields surface updates as items arrive in a dataModelUpdate stream.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        List:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                template:
+                  type: object
+                  properties:
+                    componentId: {type: string, title: "ComponentId"}
+                    dataBinding: {type: string}
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"root": "item-list", "surfaceId": "default"}}, '
+      expect: [{a2ui: [{beginRendering: {root: "item-list", surfaceId: "default"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "default", "components": [{"id": "item-list", "component": {"List": {"children": {"template": {"componentId": "template-name", "dataBinding": "/items"}}}}}, {"id": "template-name", "component": {"Text": {"text": {"path": "/name"}}}}]}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "default"
+                components:
+                  - id: "item-list"
+                    component:
+                      List:
+                        children:
+                          template:
+                            componentId: "template-name"
+                            dataBinding: "/items"
+                  - id: "template-name"
+                    component: {Text: {text: {path: "/name"}}}
+    - input: '{"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "items", "valueMap": ['
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents: [{key: "items", valueMap: []}]
+    - input: '{"key": "name", "valueString": "Item 1"}, '
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents: [{key: "items", valueMap: [{key: "name", valueString: "Item 1"}]}]
+    - input: '{"key": "name", "valueString": "Item 2"}]}]}}'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  [
+                    {
+                      key: "items",
+                      valueMap:
+                        [
+                          {key: "name", valueString: "Item 1"},
+                          {key: "name", valueString: "Item 2"},
+                        ],
+                    },
+                  ]
+    - input: "]}}}]"
+      expect: []
+
+- name: test_sniff_partial_invalid_datamodel_fails_gracefully
+  description: Verifies that sniffing a partial DM update that would fail validation doesn't crash.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "name", "valueString": "John"}, {"valueString": "incomplete"'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents: [{key: "name", valueString: "John"}]
+    - input: '{"dataModelUpdate": {"surfaceId": "default", "contents": [{"valueString": "no-key"'
+      expect: []
+
+- name: test_sniff_partial_datamodel_with_cut_key
+  description: 'Verifies that an unclosed string like {"key or {"key": "val still yields previous valid entries.'
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "infoLink", "valueString": "[More Info](x)"}, {"key'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents: [{key: "infoLink", valueString: "[More Info](x)"}]
+    - input: '": "rating", "valueString": "5 star'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "infoLink"
+                    valueString: "[More Info](x)"
+                  - key: "rating"
+                    valueString: "5 star"
+    - input: 's"}, {"key": "imageUrl", "valueString": "http://localhost:10002/static/map'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "infoLink"
+                    valueString: "[More Info](x)"
+                  - key: "rating"
+                    valueString: "5 stars"
+    - input: 's.png"}]}}] </a2ui-json>'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "infoLink"
+                    valueString: "[More Info](x)"
+                  - key: "rating"
+                    valueString: "5 stars"
+                  - key: "imageUrl"
+                    valueString: "http://localhost:10002/static/maps.png"
+
+- name: test_sniff_partial_datamodel_cumulative_unmodified_keys
+  description: Verifies that unchanged keys are retained in partial dataModelUpdates.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"}, {"key": "items", "valueMap": ['
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "title"
+                    valueString: "Top Restaurants"
+                  - key: "items"
+                    valueMap: []
+    - input: '{"key": "item1", "valueMap": [{"key": "name", "valueString": "Restaurant A"'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "title"
+                    valueString: "Top Restaurants"
+                  - key: "items"
+                    valueMap:
+                      - key: "item1"
+                        valueMap: [{key: "name", valueString: "Restaurant A"}]
+
+- name: test_sniff_partial_datamodel_prunes_empty_keys
+  description: Verifies that entries with only a key and no value are pruned from partial dataModelUpdates.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"},{"key": "items", "valueMap": [{"key": "item1", "valueMap": [{"key": "name", "valueString": "Food"}, {"key": "detail", "valueString": "Spicy"}, {}, {"key": "imageUrl'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "title"
+                    valueString: "Top Restaurants"
+                  - key: "items"
+                    valueMap:
+                      - key: "item1"
+                        valueMap:
+                          - key: "name"
+                            valueString: "Food"
+                          - key: "detail"
+                            valueString: "Spicy"
+
+- name: test_sniff_partial_datamodel_prunes_empty_trailing_dict
+  description: Verifies that an incomplete trailing empty dictionary '{}' is dropped.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"},{"key": "items", "valueMap": [{"key": "item2", "valueMap": [{"key": "name", "valueString": "Han Dynasty"}, {"key": "imageUrl", "valueString": "http://localhost:10002/static/mapotofu.jpeg"}, {}]}]} ]}] </a2ui-json>'
+      expect:
+        - a2ui:
+            - dataModelUpdate:
+                surfaceId: "default"
+                contents:
+                  - key: "title"
+                    valueString: "Top Restaurants"
+                  - key: "items"
+                    valueMap:
+                      - key: "item2"
+                        valueMap:
+                          - key: "name"
+                            valueString: "Han Dynasty"
+                          - key: "imageUrl"
+                            valueString: "http://localhost:10002/static/mapotofu.jpeg"
+
+- name: test_sniff_partial_component_discards_empty_children_dict
+  description: Verifies that an incomplete component with an empty children dictionary is discarded until populated.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Column:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList:
+                  type: array
+                  items: {type: string, title: "ComponentId"}
+        List:
+          type: object
+          additionalProperties: true
+        Row:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList:
+                  type: array
+                  items: {type: string}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"beginRendering": {"surfaceId": "default", "root": "root-column"}},'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "default", root: "root-column"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "default", "components": [{"id": "root-column", "component": {"Column": {"children": {"explicitList": ["item-list"]}}}},{"id": "item-list", "component": {"List": {"direction": "vertical", "children": {'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "default"
+                components:
+                  - id: "root-column"
+                    component:
+                      Column:
+                        children: {explicitList: ["loading_item-list"]}
+                  - id: "loading_item-list"
+                    component:
+                      Row:
+                        children: {explicitList: []}
+
+- name: test_partial_empty_dict_discarded
+  description: Tests that a component with an empty dictionary in a required field is discarded until populated.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          additionalProperties: true
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "root", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "root", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Card": {"action": {"context": [{"key": "address", "value": {'
+      expect: []
+    - input: '"literalString": "123 Main St"}}]}}}}]}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Card:
+                        action:
+                          context: [{key: "address", value: {literalString: "123 Main St"}}]
+
+- name: test_sniff_partial_component_enforces_required_fields
+  description: Tests that components missing required fields are not yielded during sniffing.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        AudioPlayer:
+          type: object
+          properties:
+            url: {type: object}
+          required: ["url"]
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"root": "c1", "surfaceId": "s1"}},'
+      expect: [{a2ui: [{beginRendering: {root: "c1", surfaceId: "s1"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"AudioPlayer": {"description": "almost ready"'
+      expect: []
+    - input: ', "url": {"literalString": "http://audio.mp3"}}}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component:
+                      AudioPlayer:
+                        description: "almost ready"
+                        url: {literalString: "http://audio.mp3"}
+
+- name: test_multiple_concurrent_surfaces
+  description: Verifies that the parser can handle multiple surfaces simultaneously.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            child: {type: string, title: "ComponentId"}
+        Text:
+          type: object
+          additionalProperties: true
+        Row:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList:
+                  type: array
+                  items: {type: string}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"beginRendering": {"surfaceId": "surface1", "root": "root1"}},'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "surface1", root: "root1"}}]}]
+    - input: '{"beginRendering": {"surfaceId": "surface2", "root": "root2"}},'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "surface2", root: "root2"}}]}]
+    - input: '{"surfaceUpdate": {"surfaceId": "surface1", "components": [{"id": "root1", "component": {"Card": {"child": "c1"}}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "surface1"
+                components:
+                  - id: "root1"
+                    component: {Card: {child: "loading_c1"}}
+                  - id: "loading_c1"
+                    component: {Row: {children: {explicitList: []}}}
+    - input: '{"id": "c1", "component": {"Text": {"text": "hello s1"}}}]}}, '
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "surface1"
+                components:
+                  - id: "c1"
+                    component: {Text: {text: "hello s1"}}
+                  - id: "root1"
+                    component: {Card: {child: "c1"}}
+    - input: '{"surfaceUpdate": {"surfaceId": "surface2", "components": [{"id": "root2", "component": {"Card": {"child": "c2"}}}, {"id": "c2", "component": {"Text": {"text": "hello s2"}}}]}}'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "surface2"
+                components:
+                  - id: "c2"
+                    component: {Text: {text: "hello s2"}}
+                  - id: "root2"
+                    component: {Card: {child: "c2"}}
+    - input: "]</a2ui-json>"
+      expect: []
+
+- name: test_incremental_yielding_v09
+  description: Tests that partial chunks are buffered and yielded correctly for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Column:
+          type: object
+          properties:
+            component: {const: "Column"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Row:
+          type: object
+          properties:
+            component: {const: "Row"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Column"}
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Row"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "Here is your"
+      expect: [{text: "Here is your"}]
+    - input: " response.<a2ui-json>["
+      expect: [{text: " response."}]
+    - input: '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId":'
+      expect: []
+    - input: ' "test_catalog'
+      expect: []
+    - input: '"'
+      expect: []
+    - input: "}},"
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {surfaceId: "s1", catalogId: "test_catalog"}}]}]
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": ['
+      expect: []
+    - input: '{"id": "root", "component": "Column", "children": ['
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Column"
+                    children: ["loading_children_root"]
+                  - id: "loading_children_root"
+                    component: "Row"
+                    children: []
+    - input: '"c1",'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Column"
+                    children: ["loading_c1"]
+                  - id: "loading_c1"
+                    component: "Row"
+                    children: []
+    - input: '"c2"]}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Column"
+                    children: ["loading_c1", "loading_c2"]
+                  - id: "loading_c1"
+                    component: "Row"
+                    children: []
+                  - id: "loading_c2"
+                    component: "Row"
+                    children: []
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "c1", "component": "Text", "text": "hello"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "hello"
+                  - id: "root"
+                    component: "Column"
+                    children: ["c1", "loading_c2"]
+                  - id: "loading_c2"
+                    component: "Row"
+                    children: []
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "c2", "component": "Text", "text": "world"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "hello"
+                  - id: "c2"
+                    component: "Text"
+                    text: "world"
+                  - id: "root"
+                    component: "Column"
+                    children: ["c1", "c2"]
+
+- name: test_waiting_for_root_component_v09
+  description: Tests that components are not yielded until reachable from root for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Card:
+          type: object
+          properties:
+            component: {const: "Card"}
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "c1", "component": "Text", "text": "hello"}'
+      expect: []
+    - input: ', {"id": "root", "component": "Card", "child": "c1"}}]}}</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "hello"
+                  - id: "root"
+                    component: "Card"
+                    child: "c1"
+
+- name: test_complete_surface_ignore_orphan_component_v09
+  description: Tests that orphan components (not reachable from root) are ignored for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": "root"}, {"id": "orphan", "component": "Text", "text": "orphan"}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "root"
+
+- name: test_circular_reference_detection_v09
+  description: Tests that circular references are detected during streaming for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Card", "child": "child"}]}},{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "child", "component": "Card", "child": "root"}]}}'
+      expect_error: "Circular reference detected"
+
+- name: test_self_reference_detection_v09
+  description: Tests that self-references are detected during streaming for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Card", "child": "root"}]}}'
+      expect_error: "Self-reference detected"
+
+- name: test_interleaved_conversational_text_v09
+  description: Tests that conversational text and A2UI content are interleaved correctly for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Dummy: {type: object}
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Dummy"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "Hello! "
+      expect: [{text: "Hello! "}]
+    - input: "Here is your UI: <a2ui-json>"
+      expect: [{text: "Here is your UI: "}]
+    - input: '[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}]'
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
+    - input: "</a2ui-json> That's all!"
+      expect: [{text: " That's all!"}]
+
+- name: test_split_tag_handling_for_text_v09
+  description: Tests that the parser handles the opening tag split across chunks correctly for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Dummy: {type: object}
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Dummy"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "Talking <a2u"
+      expect: [{text: "Talking "}]
+    - input: "i-json>"
+      expect: []
+    - input: '[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s"}}] </a2ui-json> End.'
+      expect:
+        - a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s"}}]
+        - text: " End."
+
+- name: test_create_surface_missing_catalog_id_v09
+  description: Verifies that v0.9 createSurface fails when catalogId is missing.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>"
+      expect: []
+    - input: '[{"version": "v0.9", "createSurface": {"surfaceId": "s1"}}]'
+      expect_error: "required property"
+
+- name: test_only_create_surface_v09
+  description: Tests that createSurface is yielded only when complete for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>"
+      expect: []
+    - input: "["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1", "theme": {"primaryColor": "#FF0000",'
+      expect: []
+    - input: '"font": "Roboto"}'
+      expect: []
+    - input: "}"
+      expect: []
+    - input: "}"
+      expect:
+        [
+          {
+            a2ui:
+              [
+                {
+                  version: "v0.9",
+                  createSurface:
+                    {
+                      catalogId: "test_catalog",
+                      surfaceId: "s1",
+                      theme: {primaryColor: "#FF0000", font: "Roboto"},
+                    },
+                },
+              ],
+          },
+        ]
+
+- name: test_multiple_a2ui_blocks_v09
+  description: Tests that multiple A2UI blocks are handled correctly with interleaved text for v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: 'Some text here <a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}] </a2ui-json> mid text'
+      expect:
+        - text: "Some text here "
+          a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]
+        - text: " mid text"
+    - input: ' more text <a2ui-json>[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": "block2"}]}}] </a2ui-json> trailing text'
+      expect:
+        - text: " more text "
+          a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "block2"
+        - text: " trailing text"
+
+- name: test_partial_json_and_incremental_yielding_v09
+  description: Tests that partial JSON yields incremental updates.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": "hello'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "hello"
+
+- name: test_partial_single_child_string_v09
+  description: Tests that partial single child string yields placeholder.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Card:
+          type: object
+          properties:
+            component: {const: "Card"}
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Card", "child": "c1"}'
+      expect: []
+    - input: ', {"id": "c1", "component": "Text", "text": "child 1"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "child 1"
+                  - id: "root"
+                    component: "Card"
+                    child: "c1"
+
+- name: test_partial_template_componentId_v09
+  description: Tests that partial template componentId yields placeholder after path is seen.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        List:
+          type: object
+          properties:
+            component: {const: "List"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/List"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "List", "children": {"componentId": "c1"'
+      expect: []
+    - input: ', "path": "/items"'
+      expect: []
+    - input: '}}, {"id": "c1", "component": "Text", "text": "child 1"}]}} </a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "child 1"
+                  - id: "root"
+                    component: "List"
+                    children: {componentId: "c1", path: "/items"}
+
+- name: test_partial_children_lists_v09
+  description: Tests that partial children lists yield placeholders.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Container:
+          type: object
+          properties:
+            component: {const: "Container"}
+            children: {type: array, items: {type: string}}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Container"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Container", "children": ["c1", "c2", "c3"]}'
+      expect: []
+    - input: ', {"id": "c1", "component": "Text", "text": "child 1"}]}} </a2ui-json>'
+      expect: []
+
+- name: test_data_model_before_components_v09
+  description: Tests that data model before components works.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              oneOf:
+                - {type: string}
+                - type: object
+                  properties:
+                    path: {type: string}
+                  required: ["path"]
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "s1", "value": {"name": "Alice"}}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "s1"
+                value: {name: "Alice"}
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": {"path": "/name"}}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: {path: "/name"}
+
+- name: test_data_model_after_components_v09
+  description: Tests that data model after components works.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              oneOf:
+                - {type: string}
+                - type: object
+                  properties:
+                    path: {type: string}
+                  required: ["path"]
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": {"path": "/name"}}]}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: {path: "/name"}
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "s1", "value": {"name": "Alice"}}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "s1"
+                value: {name: "Alice"}
+
+- name: test_partial_paths_v09
+  description: Tests that partial paths are buffered.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              type: object
+              properties:
+                path: {type: string}
+              required: ["path"]
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": {"path": "/loca'
+      expect: []
+    - input: 'tion"}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: {path: "/location"}
+
+- name: test_cut_atomic_id_v09
+  description: Tests that atomic IDs are buffered when cut.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Card:
+          type: object
+          properties:
+            component: {const: "Card"}
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "contact'
+      expect: []
+    - input: '-card"}}, {"version": "v0.9", "updateComponents": {"surfaceId": "contact-card", "components": [{"id": "button'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "contact-card"
+                catalogId: "test_catalog"
+    - input: '-text"'
+      expect: []
+    - input: ', "component": "Text", "text": "hi"}, {"id": "root", "component": "Card", "child": "button-text"}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "contact-card"
+                components:
+                  - id: "button-text"
+                    component: "Text"
+                    text: "hi"
+                  - id: "root"
+                    component: "Card"
+                    child: "button-text"
+
+- name: test_cut_cuttable_text_v09
+  description: Tests that cuttable text is yielded incrementally.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": "Em'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "Em"
+    - input: 'ail"}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "Email"
+
+- name: test_message_ordering_buffering_v09
+  description: Tests that updateComponents is buffered until createSurface arrives.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": "hi"}]}}, '
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "hi"
+
+- name: test_delete_surface_buffering_v09
+  description: Tests that deleteSurface before createSurface is ignored.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "deleteSurface": {"surfaceId": "s1"}}, '
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+
+- name: test_cut_path_v09
+  description: Tests that cutting non-cuttable path buffers the component.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              oneOf:
+                - {type: string}
+                - type: object
+                  properties:
+                    path: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": {"path": "/user'
+      expect: []
+    - input: '/profile"}}}}]}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: {path: "/user/profile"}
+
+- name: test_strict_begin_rendering_validation_v09
+  description: Tests that invalid message fails validation.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"unknownMessage": "invalid"}]'
+      expect_error: "Validation failed"
+
+- name: test_yield_validation_failure_v09
+  description: Tests that missing required fields fail validation.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component", "text"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"updateComponents": {"components": []}}'
+      expect_error: "Validation failed"
+
+- name: test_delta_streaming_correctness_v09
+  description: Tests that the parser correctly assembles components from small deltas.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>"
+      expect: []
+    - input: "["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: ', {"updateComponents": {"surfaceId": "s1", "components": ['
+      expect: []
+    - input: '{"id": "root", "compon'
+      expect: []
+    - input: 'ent": "Text", "text": "hello'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "hello"
+    - input: " world"
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: "hello world"
+
+- name: test_multiple_re_yielding_scenarios_v09
+  description: Tests that updateDataModel yields expected updates.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Container:
+          type: object
+          properties:
+            component: {const: "Container"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              oneOf:
+                - {type: string}
+                - type: object
+                  properties:
+                    path: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Container"}
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Container", "children": ["c1", "c2"]}, {"id": "c1", "component": "Text", "text": {"path": "/p1"}}, {"id": "c2", "component": "Text", "text": {"path": "/p2"}}]}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: {path: "/p1"}
+                  - id: "c2"
+                    component: "Text"
+                    text: {path: "/p2"}
+                  - id: "root"
+                    component: "Container"
+                    children: ["c1", "c2"]
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "s1", "value": {"p1": "v1"}}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "s1"
+                value: {p1: "v1"}
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "s1", "value": {"p2": "v2"}}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "s1"
+                value: {p2: "v2"}
+
+- name: test_incremental_data_model_streaming_v09
+  description: Tests that the parser yields surface updates as items arrive in a updateDataModel stream.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        List:
+          type: object
+          properties:
+            component: {const: "List"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text:
+              oneOf:
+                - {type: string}
+                - type: object
+                  properties:
+                    path: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/List"}
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "default"}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "default"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "default", "components": [{"id": "root", "component": "List", "children": {"componentId": "template-name", "path": "/items"}}, {"id": "template-name", "component": "Text", "text": {"path": "/name"}}]}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "default"
+                components:
+                  - id: "root"
+                    component: "List"
+                    children: {componentId: "template-name", path: "/items"}
+                  - id: "template-name"
+                    component: "Text"
+                    text: {path: "/name"}
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"items": {'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value: {items: {}}
+    - input: '"item1": {"name": "Item 1"}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  items: {item1: {name: "Item 1"}}
+    - input: '"item2": {"name": "Item 2"}}}}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  items:
+                    item1: {name: "Item 1"}
+                    item2: {name: "Item 2"}
+
+- name: test_sniff_partial_invalid_datamodel_fails_gracefully_v09
+  description: Tests that sniffing a partial DM update that would fail validation doesn't crash.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"name": "John", "incomplete": '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value: {name: "John"}
+    - input: '<a2ui-json>{"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"unnamed":'
+      expect: []
+
+- name: test_sniff_partial_datamodel_with_cut_key_v09
+  description: Tests that an unclosed string yields previous valid entries.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"infoLink": "[More Info](x)", "rat'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value: {infoLink: "[More Info](x)"}
+    - input: 'ing": "5 star"'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value: {rating: "5 star"}
+    - input: ', "imageUrl": "http://localhost:10002/static/map'
+      expect: []
+    - input: 's.png"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  imageUrl: "http://localhost:10002/static/maps.png"
+
+- name: test_sniff_partial_datamodel_cumulative_unmodified_keys_v09
+  description: Tests that unchanged keys are retained in partial updateDataModels.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"title": "Top Restaurants", "items": {'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  title: "Top Restaurants"
+                  items: {}
+    - input: '"item1": {"name": "Restaurant A"}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  items: {item1: {name: "Restaurant A"}}
+
+- name: test_sniff_partial_datamodel_prunes_empty_keys_v09
+  description: Tests that entries with only a key and no value are pruned.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"title": "Top Restaurants","items": {"item1": {"name": "Food", "detail": "Spicy", "imageUrl":'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  title: "Top Restaurants"
+                  items:
+                    item1:
+                      name: "Food"
+                      detail: "Spicy"
+
+- name: test_sniff_partial_datamodel_prunes_empty_trailing_dict_v09
+  description: Tests that an incomplete trailing empty dictionary is dropped.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components: {}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[ {"version": "v0.9", "updateDataModel": {"surfaceId": "default", "value": {"title": "Top Restaurants","items": {"item2": {"name": "Han Dynasty", "imageUrl": "http://localhost:10002/static/mapotofu.jpeg", "broken":'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateDataModel:
+                surfaceId: "default"
+                value:
+                  title: "Top Restaurants"
+                  items:
+                    item2:
+                      name: "Han Dynasty"
+                      imageUrl: "http://localhost:10002/static/mapotofu.jpeg"
+
+- name: test_sniff_partial_component_discards_empty_children_dict_v09
+  description: Tests that an incomplete component with an empty children dictionary is discarded.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Column:
+          type: object
+          properties:
+            component: {const: "Column"}
+            children: {type: array, items: {type: string}}
+          required: ["component"]
+        List:
+          type: object
+          properties:
+            component: {const: "List"}
+            direction: {type: string}
+            children:
+              type: object
+              properties:
+                componentId: {type: string}
+                path: {type: string}
+          required: ["component"]
+        Row:
+          type: object
+          properties:
+            component: {const: "Row"}
+            children: {type: array, items: {type: string}}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Column"}
+            - {$ref: "#/components/List"}
+            - {$ref: "#/components/Row"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "default"}},{"version": "v0.9", "updateComponents": {"surfaceId": "default", "components": [{"id": "root", "component": "Column", "children": ["item-list"]},{"id": "item-list", "component": "List", "direction": "vertical", "children": {'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "default"
+                catalogId: "test_catalog"
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "default"
+                components:
+                  - id: "root"
+                    component: "Column"
+                    children: ["loading_item-list"]
+                  - id: "loading_item-list"
+                    component: "Row"
+                    children: []
+
+- name: test_partial_empty_dict_discarded_v09
+  description: Tests that partial empty dict is discarded until populated.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Column:
+          type: object
+          properties:
+            component: {const: "Column"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Column"}
+            - {$ref: "#/components/Text"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Column", "children": {'
+      expect: []
+    - input: '"componentId": "c1", "path": "/items"}}, {"id": "c1", "component": "Text", "text": "Child 1"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "Child 1"
+                  - id: "root"
+                    component: "Column"
+                    children: {componentId: "c1", path: "/items"}
+
+- name: test_sniff_partial_component_enforces_required_fields_v09
+  description: Tests that partial component is discarded if it lacks required fields.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        AudioPlayer:
+          type: object
+          properties:
+            component: {const: "AudioPlayer"}
+            description: {type: string}
+            url: {type: string}
+          required: ["component", "url"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/AudioPlayer"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"catalogId": "test_catalog", "surfaceId": "s1"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "AudioPlayer", "description": "almost ready"'
+      expect: []
+    - input: ', "url": "http://audio.mp3"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "AudioPlayer"
+                    description: "almost ready"
+                    url: "http://audio.mp3"
+
+- name: test_multiple_concurrent_surfaces_v09
+  description: Tests that the parser can handle multiple surfaces simultaneously.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            component: {const: "Card"}
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required: ["component"]
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: ["component"]
+        Row:
+          type: object
+          properties:
+            component: {const: "Row"}
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required: ["component"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Card"}
+            - {$ref: "#/components/Text"}
+            - {$ref: "#/components/Row"}
+          discriminator: {propertyName: "component"}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>["
+      expect: []
+    - input: '{"version": "v0.9", "createSurface": {"surfaceId": "surface1", "catalogId": "test_catalog"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "surface1"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "createSurface": {"surfaceId": "surface2", "catalogId": "test_catalog"}},'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "surface2"
+                catalogId: "test_catalog"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "surface1", "components": [{"id": "root", "component": "Card", "child": "c1"}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "surface1"
+                components:
+                  - id: "root"
+                    component: "Card"
+                    child: "loading_c1"
+                  - id: "loading_c1"
+                    component: "Row"
+                    children: []
+    - input: '{"id": "c1", "component": "Text", "text": "hello s1"}]}}, '
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "surface1"
+                components:
+                  - id: "c1"
+                    component: "Text"
+                    text: "hello s1"
+                  - id: "root"
+                    component: "Card"
+                    child: "c1"
+    - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "surface2", "components": [{"id": "root", "component": "Card", "child": "c2"}, {"id": "c2", "component": "Text", "text": "hello s2"}]}}'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "surface2"
+                components:
+                  - id: "c2"
+                    component: "Text"
+                    text: "hello s2"
+                  - id: "root"
+                    component: "Card"
+                    child: "c2"
+
+- name: test_invalid_json_error
+  description: Tests that completely invalid JSON inside A2UI tags raises an error.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema: {catalogId: "test_catalog", components: {}}
+  action: process_chunk
+  steps:
+    - input: "<a2ui-json>invalid json</a2ui-json>"
+      expect_error: "Failed to parse JSON"
+
+- name: test_v08_path_heuristic_adds_slash
+  description: Tests that the parser automatically adds a leading slash to paths in v0.8 if missing.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"beginRendering": {"surfaceId": "s1", "root": "root"}}]</a2ui-json>'
+      expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "root"}}]}]
+    - input: '<a2ui-json>[{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {"text": {"path": "some/relative/path"}}}}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - surfaceUpdate:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component:
+                      Text:
+                        text: {path: "/some/relative/path"}
+
+- name: test_v09_path_heuristic_relative_path
+  description: Tests that the parser does NOT add a leading slash to paths in v0.9.
+  catalog:
+    version: "0.9"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+              properties:
+                path: {type: string}
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test_catalog"}}]</a2ui-json>'
+      expect:
+        [{a2ui: [{version: "v0.9", createSurface: {surfaceId: "s1", catalogId: "test_catalog"}}]}]
+    - input: '<a2ui-json>[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "text": {"path": "some/relative/path"}}]}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    text: {path: "some/relative/path"}
+
+- name: test_custom_cuttable_keys
+  description: Tests that the streaming parser respects custom cuttable_keys from catalog.
+  catalog:
+    version: "0.9"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema: {catalogId: "c1"}
+    custom_cuttable_keys: ["customCuttable"]
+  disable_validation: true
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "c1"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "c1"
+    - input: '<a2ui-json>[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "customCuttable": "partial'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    customCuttable: "partial"

--- a/Tests/A2UIConformanceTests/Resources/suites/validator.yaml
+++ b/Tests/A2UIConformanceTests/Resources/suites/validator.yaml
@@ -1,0 +1,2771 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: test_validator_circular_reference_v08
+  description: Tests that circular references are detected.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: test_catalog
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        root: c1
+        surfaceId: s1
+    - surfaceUpdate:
+        surfaceId: s1
+        components:
+          - id: c1
+            component:
+              Card:
+                child: c2
+          - id: c2
+            component:
+              Card:
+                child: c1
+  expect_error:
+    category: "RecursionError"
+    message: "Circular reference detected"
+
+- name: test_validator_0_9
+  description: Tests validation of v0.9 messages.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema: "test_data/simplified_catalog_v09.json"
+  action: validate
+  steps:
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: test-id
+            catalogId: standard
+            theme:
+              primaryColor: blue
+              iconUrl: http://img
+    - payload:
+        - createSurface:
+            surfaceId: "123"
+            catalogId: standard
+      expect_error:
+        category: "ValidationError"
+        details:
+          - path: "messages.0.version"
+            code: "missing_field"
+    - payload:
+        - version: v0.8
+          createSurface:
+            surfaceId: "123"
+            catalogId: standard
+      expect_error:
+        category: "ValidationError"
+        details:
+          - path: "messages.0.version"
+            code: "invalid_value"
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: 123
+            catalogId: standard
+      expect_error:
+        category: "ValidationError"
+        details:
+          - path: "messages.0.createSurface.surfaceId"
+            code: "type_mismatch"
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: "123"
+      expect_error:
+        category: "ValidationError"
+        details:
+          - path: "messages.0.createSurface.catalogId"
+            code: "missing_field"
+
+- name: test_validator_0_8
+  description: Tests validation of v0.8 messages.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components: {}
+  action: validate
+  steps:
+    - payload:
+        - beginRendering:
+            surfaceId: test-id
+            root: root
+            styles:
+              primaryColor: "#ff0000"
+    - payload:
+        - beginRendering:
+            surfaceId: 123
+            root: root
+      expect_error: 123 is not of type 'string'
+    - payload:
+        - beginRendering:
+            surfaceId: id
+            root: root
+            styles: not-an-object
+      expect_error: "'not-an-object' is not of type 'object'"
+
+- name: test_custom_catalog_0_8
+  description: Tests validation with a custom catalog in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: custom
+      components:
+        Canvas:
+          type: object
+          properties:
+            children:
+              type: object
+              properties:
+                explicitList:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - explicitList
+          required:
+            - children
+        Chart:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - doughnut
+                - pie
+            title:
+              type: object
+              properties:
+                literalString:
+                  type: string
+                path:
+                  type: string
+            chartData:
+              type: object
+              properties:
+                literalArray:
+                  type: array
+                path:
+                  type: string
+          required:
+            - type
+            - chartData
+        GoogleMap:
+          type: object
+          properties:
+            center:
+              type: object
+              properties:
+                literalObject:
+                  type: object
+                path:
+                  type: string
+            zoom:
+              type: object
+              properties:
+                literalNumber:
+                  type: number
+                path:
+                  type: string
+          required:
+            - center
+            - zoom
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: id1
+        components:
+          - id: root
+            component:
+              Canvas:
+                children:
+                  explicitList:
+                    - c1
+                    - c2
+          - id: c1
+            component:
+              Canvas:
+                children:
+                  explicitList: []
+          - id: c2
+            component:
+              Chart:
+                type: pie
+                chartData:
+                  path: /data
+
+- name: test_custom_catalog_0_9
+  description: Tests validation with a custom catalog in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: custom
+      components:
+        Canvas:
+          type: object
+          allOf:
+            - $ref: "#/$defs/ComponentCommon"
+            - $ref: "#/$defs/CatalogComponentCommon"
+            - type: object
+              properties:
+                component:
+                  const: Canvas
+                children:
+                  $ref: "#/$defs/ChildList"
+              required:
+                - component
+                - children
+        Chart:
+          type: object
+          allOf:
+            - $ref: "#/$defs/ComponentCommon"
+            - $ref: "#/$defs/CatalogComponentCommon"
+            - type: object
+              properties:
+                component:
+                  const: Chart
+                chartType:
+                  enum:
+                    - doughnut
+                    - pie
+                title:
+                  $ref: "#/$defs/DynamicString"
+                chartData:
+                  $ref: "#/$defs/DynamicValue"
+              required:
+                - component
+                - chartType
+                - chartData
+        GoogleMap:
+          type: object
+          allOf:
+            - $ref: "#/$defs/ComponentCommon"
+            - $ref: "#/$defs/CatalogComponentCommon"
+            - type: object
+              properties:
+                component:
+                  const: GoogleMap
+                center:
+                  $ref: "#/$defs/DynamicValue"
+                zoom:
+                  $ref: "#/$defs/DynamicNumber"
+                pins:
+                  $ref: "#/$defs/DynamicValue"
+              required:
+                - component
+                - center
+                - zoom
+      $defs:
+        ComponentId:
+          type: string
+        ComponentCommon:
+          type: object
+          properties:
+            id:
+              $ref: "#/$defs/ComponentId"
+          required:
+            - id
+        ChildList:
+          oneOf:
+            - type: array
+              items:
+                $ref: "#/$defs/ComponentId"
+            - type: object
+              properties:
+                componentId:
+                  $ref: "#/$defs/ComponentId"
+                path:
+                  type: string
+              required:
+                - componentId
+                - path
+              additionalProperties: false
+        DynamicString:
+          anyOf:
+            - type: string
+            - type: object
+        DynamicValue:
+          anyOf:
+            - type: object
+            - type: array
+        DynamicNumber:
+          anyOf:
+            - type: number
+            - type: object
+        CatalogComponentCommon:
+          type: object
+          properties:
+            weight:
+              type: number
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Canvas"
+            - $ref: "#/components/Chart"
+            - $ref: "#/components/GoogleMap"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: s1
+        components:
+          - id: root
+            component: Canvas
+            children:
+              - c1
+              - c2
+          - id: c1
+            component: Canvas
+            children: []
+          - id: c2
+            component: Chart
+            chartType: doughnut
+            chartData:
+              path: /data
+
+- name: test_validate_duplicate_ids_v08
+  description: Tests that duplicate IDs are detected in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        root: root
+        surfaceId: test-surface
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Text:
+                text: Root
+          - id: c1
+            component:
+              Text:
+                text: Hello
+          - id: c1
+            component:
+              Text:
+                text: World
+  expect_error:
+    category: "IntegrityError"
+    message: "Duplicate component ID: c1"
+
+- name: test_validate_duplicate_ids_v09
+  description: Tests that duplicate IDs are detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Text
+            text: Root
+          - id: c1
+            component: Text
+            text: Hello
+          - id: c1
+            component: Text
+            text: World
+  expect_error: "Duplicate component ID: c1"
+
+- name: test_validate_missing_root_v08
+  description: Tests that missing root component is detected in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        root: root
+        surfaceId: test
+    - surfaceUpdate:
+        surfaceId: test
+        components:
+          - id: c1
+            component:
+              Text:
+                text: hi
+  expect_error:
+    category: "IntegrityError"
+    message: "Missing root component"
+
+- name: test_validate_missing_root_v09
+  description: Tests that missing root component is detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test
+        components:
+          - id: c1
+            component: Text
+            text: hi
+  expect_error: Missing root component
+
+- name: test_validate_dangling_references_v08
+  description: Tests that dangling references are detected in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Column:
+          type: object
+          properties:
+            children:
+              type: array
+              items:
+                type: string
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  steps:
+    - payload:
+        - beginRendering:
+            root: root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component:
+                  Column:
+                    children:
+                      - missing
+      expect_error: references non-existent component
+    - payload:
+        - beginRendering:
+            root: root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component:
+                  Card:
+                    child: missing
+      expect_error: references non-existent component
+
+- name: test_validate_dangling_references_v09
+  description: Tests that dangling references are detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Column:
+          type: object
+          properties:
+            component:
+              const: Column
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required:
+            - component
+            - children
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Column"
+            - $ref: "#/components/Card"
+          discriminator:
+            propertyName: component
+  action: validate
+  steps:
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: test-surface
+            catalogId: std
+        - version: v0.9
+          updateComponents:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component: Column
+                children:
+                  - missing
+      expect_error: references non-existent component
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: test-surface
+            catalogId: std
+        - version: v0.9
+          updateComponents:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component: Card
+                child: missing
+      expect_error: references non-existent component
+
+- name: test_validate_self_reference_v08
+  description: Tests that self-references are detected in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        root: root
+        surfaceId: test-surface
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Card:
+                child: root
+  expect_error: Self-reference detected
+
+- name: test_validate_self_reference_v09
+  description: Tests that self-references are detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Card
+            child: root
+  expect_error: Self-reference detected
+
+- name: test_validate_function_call_recursion_v08
+  description: Tests that function call recursion limit is exceeded in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Button:
+          type: object
+          properties:
+            label:
+              type: string
+            action:
+              type: object
+  action: validate
+  payload:
+    - beginRendering:
+        root: root
+        surfaceId: test-surface
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Button:
+                label: btn
+                action:
+                  functionCall:
+                    call: f0
+                    args:
+                      functionCall:
+                        call: f1
+                        args:
+                          functionCall:
+                            call: f2
+                            args:
+                              functionCall:
+                                call: f3
+                                args:
+                                  functionCall:
+                                    call: f4
+                                    args:
+                                      functionCall:
+                                        call: f5
+                                        args: {}
+  expect_error: "Recursion limit exceeded: functionCall depth > 5"
+
+- name: test_validate_function_call_recursion_v09
+  description: Tests that function call recursion limit is exceeded in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Button:
+          type: object
+          properties:
+            component:
+              const: Button
+            text:
+              type: string
+            action:
+              type: object
+          required:
+            - component
+            - text
+            - action
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Button"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Button
+            text: btn
+            action:
+              functionCall:
+                call: f0
+                args:
+                  functionCall:
+                    call: f1
+                    args:
+                      functionCall:
+                        call: f2
+                        args:
+                          functionCall:
+                            call: f3
+                            args:
+                              functionCall:
+                                call: f4
+                                args:
+                                  functionCall:
+                                    call: f5
+                                    args: {}
+  expect_error: "Recursion limit exceeded: functionCall depth > 5"
+
+- name: test_validate_orphaned_component_v08
+  description: Tests that orphaned components are detected in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        root: root
+        surfaceId: test-surface
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Text:
+                text: Root
+          - id: orphan
+            component:
+              Text:
+                text: Orphan
+  expect_error: Component 'orphan' is not reachable from 'root'
+
+- name: test_validate_orphaned_component_v09
+  description: Tests that orphaned components are detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Text
+            text: Root
+          - id: orphan
+            component: Text
+            text: Orphan
+  expect_error: Component 'orphan' is not reachable from 'root'
+
+- name: test_validate_template_reachability_v08
+  description: Tests template reachability in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Column:
+          type: object
+          properties:
+            children:
+              type: array
+              items:
+                type: string
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  steps:
+    - payload:
+        - beginRendering:
+            root: root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component:
+                  Column:
+                    children:
+                      - template-id
+              - id: template-id
+                component:
+                  Text:
+                    text: Reachable
+    - payload:
+        - beginRendering:
+            root: root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component:
+                  Column:
+                    children:
+                      - missing-id
+              - id: template-id
+                component:
+                  Text:
+                    text: Reachable
+      expect_error: references non-existent component 'missing-id'
+
+- name: test_validate_template_reachability_v09
+  description: Tests template reachability in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        List:
+          type: object
+          properties:
+            component:
+              const: List
+            children:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
+          required:
+            - component
+            - children
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/List"
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  steps:
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: test-surface
+            catalogId: std
+        - version: v0.9
+          updateComponents:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component: List
+                children:
+                  componentId: template-id
+                  path: /items
+              - id: template-id
+                component: Text
+                text: Reachable
+    - payload:
+        - version: v0.9
+          createSurface:
+            surfaceId: test-surface
+            catalogId: std
+        - version: v0.9
+          updateComponents:
+            surfaceId: test-surface
+            components:
+              - id: root
+                component: List
+                children:
+                  componentId: missing-id
+                  path: /items
+              - id: template-id
+                component: Text
+                text: Reachable
+      expect_error: references non-existent component 'missing-id'
+
+- name: test_validate_v08_custom_root_reachability
+  description: Tests custom root reachability in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  steps:
+    - payload:
+        - beginRendering:
+            root: custom-root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: custom-root
+                component:
+                  Text:
+                    text: I am the root
+              - id: orphan
+                component:
+                  Text:
+                    text: I am an orphan
+      expect_error: Component 'orphan' is not reachable from 'custom-root'
+    - payload:
+        - beginRendering:
+            root: custom-root
+            surfaceId: test-surface
+        - surfaceUpdate:
+            surfaceId: test-surface
+            components:
+              - id: custom-root
+                component:
+                  Card:
+                    child: orphan
+              - id: orphan
+                component:
+                  Text:
+                    text: I am no longer an orphan
+
+- name: test_validate_invalid_paths_v08
+  description: Tests invalid paths in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: object
+  action: validate
+  payload:
+    - dataModelUpdate:
+        surfaceId: surface1
+        path: /invalid/escape/~2
+        contents:
+          - key: dummy
+            valueString: data
+  expect_error: (Invalid path syntax|is not valid under any of the given schemas)
+
+- name: test_validate_invalid_paths_v09
+  description: Tests invalid paths in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: object
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Text
+            text:
+              path: /invalid/escape/~2
+  expect_error: (Invalid path syntax|is not valid under any of the given schemas)
+
+- name: test_validate_component_nesting_depth_limit_exceeded_v08
+  description: Tests that global recursion limit is exceeded in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        surfaceId: test-surface
+        root: root
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Card:
+                child: c0
+          - id: c0
+            component:
+              Card:
+                child: c1
+          - id: c1
+            component:
+              Card:
+                child: c2
+          - id: c2
+            component:
+              Card:
+                child: c3
+          - id: c3
+            component:
+              Card:
+                child: c4
+          - id: c4
+            component:
+              Card:
+                child: c5
+          - id: c5
+            component:
+              Card:
+                child: c6
+          - id: c6
+            component:
+              Card:
+                child: c7
+          - id: c7
+            component:
+              Card:
+                child: c8
+          - id: c8
+            component:
+              Card:
+                child: c9
+          - id: c9
+            component:
+              Card:
+                child: c10
+          - id: c10
+            component:
+              Card:
+                child: c11
+          - id: c11
+            component:
+              Card:
+                child: c12
+          - id: c12
+            component:
+              Card:
+                child: c13
+          - id: c13
+            component:
+              Card:
+                child: c14
+          - id: c14
+            component:
+              Card:
+                child: c15
+          - id: c15
+            component:
+              Card:
+                child: c16
+          - id: c16
+            component:
+              Card:
+                child: c17
+          - id: c17
+            component:
+              Card:
+                child: c18
+          - id: c18
+            component:
+              Card:
+                child: c19
+          - id: c19
+            component:
+              Card:
+                child: c20
+          - id: c20
+            component:
+              Card:
+                child: c21
+          - id: c21
+            component:
+              Card:
+                child: c22
+          - id: c22
+            component:
+              Card:
+                child: c23
+          - id: c23
+            component:
+              Card:
+                child: c24
+          - id: c24
+            component:
+              Card:
+                child: c25
+          - id: c25
+            component:
+              Card:
+                child: c26
+          - id: c26
+            component:
+              Card:
+                child: c27
+          - id: c27
+            component:
+              Card:
+                child: c28
+          - id: c28
+            component:
+              Card:
+                child: c29
+          - id: c29
+            component:
+              Card:
+                child: c30
+          - id: c30
+            component:
+              Card:
+                child: c31
+          - id: c31
+            component:
+              Card:
+                child: c32
+          - id: c32
+            component:
+              Card:
+                child: c33
+          - id: c33
+            component:
+              Card:
+                child: c34
+          - id: c34
+            component:
+              Card:
+                child: c35
+          - id: c35
+            component:
+              Card:
+                child: c36
+          - id: c36
+            component:
+              Card:
+                child: c37
+          - id: c37
+            component:
+              Card:
+                child: c38
+          - id: c38
+            component:
+              Card:
+                child: c39
+          - id: c39
+            component:
+              Card:
+                child: c40
+          - id: c40
+            component:
+              Card:
+                child: c41
+          - id: c41
+            component:
+              Card:
+                child: c42
+          - id: c42
+            component:
+              Card:
+                child: c43
+          - id: c43
+            component:
+              Card:
+                child: c44
+          - id: c44
+            component:
+              Card:
+                child: c45
+          - id: c45
+            component:
+              Card:
+                child: c46
+          - id: c46
+            component:
+              Card:
+                child: c47
+          - id: c47
+            component:
+              Card:
+                child: c48
+          - id: c48
+            component:
+              Card:
+                child: c49
+          - id: c49
+            component:
+              Card:
+                child: c50
+          - id: c50
+            component:
+              Card:
+                child: c51
+          - id: c51
+            component:
+              Card:
+                child: c52
+          - id: c52
+            component:
+              Card:
+                child: c53
+          - id: c53
+            component:
+              Card:
+                child: c54
+          - id: c54
+            component:
+              Card:
+                child: c55
+          - id: c55
+            component:
+              Text:
+                text: End
+  expect_error: "Global recursion limit exceeded: logical depth"
+
+- name: test_validate_recursion_limit_exceeded_v09
+  description: Tests that global recursion limit is exceeded in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Card
+            child: c0
+          - id: c0
+            component: Card
+            child: c1
+          - id: c1
+            component: Card
+            child: c2
+          - id: c2
+            component: Card
+            child: c3
+          - id: c3
+            component: Card
+            child: c4
+          - id: c4
+            component: Card
+            child: c5
+          - id: c5
+            component: Card
+            child: c6
+          - id: c6
+            component: Card
+            child: c7
+          - id: c7
+            component: Card
+            child: c8
+          - id: c8
+            component: Card
+            child: c9
+          - id: c9
+            component: Card
+            child: c10
+          - id: c10
+            component: Card
+            child: c11
+          - id: c11
+            component: Card
+            child: c12
+          - id: c12
+            component: Card
+            child: c13
+          - id: c13
+            component: Card
+            child: c14
+          - id: c14
+            component: Card
+            child: c15
+          - id: c15
+            component: Card
+            child: c16
+          - id: c16
+            component: Card
+            child: c17
+          - id: c17
+            component: Card
+            child: c18
+          - id: c18
+            component: Card
+            child: c19
+          - id: c19
+            component: Card
+            child: c20
+          - id: c20
+            component: Card
+            child: c21
+          - id: c21
+            component: Card
+            child: c22
+          - id: c22
+            component: Card
+            child: c23
+          - id: c23
+            component: Card
+            child: c24
+          - id: c24
+            component: Card
+            child: c25
+          - id: c25
+            component: Card
+            child: c26
+          - id: c26
+            component: Card
+            child: c27
+          - id: c27
+            component: Card
+            child: c28
+          - id: c28
+            component: Card
+            child: c29
+          - id: c29
+            component: Card
+            child: c30
+          - id: c30
+            component: Card
+            child: c31
+          - id: c31
+            component: Card
+            child: c32
+          - id: c32
+            component: Card
+            child: c33
+          - id: c33
+            component: Card
+            child: c34
+          - id: c34
+            component: Card
+            child: c35
+          - id: c35
+            component: Card
+            child: c36
+          - id: c36
+            component: Card
+            child: c37
+          - id: c37
+            component: Card
+            child: c38
+          - id: c38
+            component: Card
+            child: c39
+          - id: c39
+            component: Card
+            child: c40
+          - id: c40
+            component: Card
+            child: c41
+          - id: c41
+            component: Card
+            child: c42
+          - id: c42
+            component: Card
+            child: c43
+          - id: c43
+            component: Card
+            child: c44
+          - id: c44
+            component: Card
+            child: c45
+          - id: c45
+            component: Card
+            child: c46
+          - id: c46
+            component: Card
+            child: c47
+          - id: c47
+            component: Card
+            child: c48
+          - id: c48
+            component: Card
+            child: c49
+          - id: c49
+            component: Card
+            child: c50
+          - id: c50
+            component: Card
+            child: c51
+          - id: c51
+            component: Card
+            child: c52
+          - id: c52
+            component: Card
+            child: c53
+          - id: c53
+            component: Card
+            child: c54
+          - id: c54
+            component: Card
+            child: c55
+          - id: c55
+            component: Text
+            text: End
+  expect_error: "Global recursion limit exceeded: logical depth"
+
+- name: test_validate_recursion_limit_valid_v08
+  description: Tests that global recursion limit is valid in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        surfaceId: test-surface
+        root: root
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              Card:
+                child: c0
+          - id: c0
+            component:
+              Card:
+                child: c1
+          - id: c1
+            component:
+              Card:
+                child: c2
+          - id: c2
+            component:
+              Card:
+                child: c3
+          - id: c3
+            component:
+              Card:
+                child: c4
+          - id: c4
+            component:
+              Card:
+                child: c5
+          - id: c5
+            component:
+              Card:
+                child: c6
+          - id: c6
+            component:
+              Card:
+                child: c7
+          - id: c7
+            component:
+              Card:
+                child: c8
+          - id: c8
+            component:
+              Card:
+                child: c9
+          - id: c9
+            component:
+              Card:
+                child: c10
+          - id: c10
+            component:
+              Card:
+                child: c11
+          - id: c11
+            component:
+              Card:
+                child: c12
+          - id: c12
+            component:
+              Card:
+                child: c13
+          - id: c13
+            component:
+              Card:
+                child: c14
+          - id: c14
+            component:
+              Card:
+                child: c15
+          - id: c15
+            component:
+              Card:
+                child: c16
+          - id: c16
+            component:
+              Card:
+                child: c17
+          - id: c17
+            component:
+              Card:
+                child: c18
+          - id: c18
+            component:
+              Card:
+                child: c19
+          - id: c19
+            component:
+              Card:
+                child: c20
+          - id: c20
+            component:
+              Card:
+                child: c21
+          - id: c21
+            component:
+              Card:
+                child: c22
+          - id: c22
+            component:
+              Card:
+                child: c23
+          - id: c23
+            component:
+              Card:
+                child: c24
+          - id: c24
+            component:
+              Card:
+                child: c25
+          - id: c25
+            component:
+              Card:
+                child: c26
+          - id: c26
+            component:
+              Card:
+                child: c27
+          - id: c27
+            component:
+              Card:
+                child: c28
+          - id: c28
+            component:
+              Card:
+                child: c29
+          - id: c29
+            component:
+              Card:
+                child: c30
+          - id: c30
+            component:
+              Card:
+                child: c31
+          - id: c31
+            component:
+              Card:
+                child: c32
+          - id: c32
+            component:
+              Card:
+                child: c33
+          - id: c33
+            component:
+              Card:
+                child: c34
+          - id: c34
+            component:
+              Card:
+                child: c35
+          - id: c35
+            component:
+              Card:
+                child: c36
+          - id: c36
+            component:
+              Card:
+                child: c37
+          - id: c37
+            component:
+              Card:
+                child: c38
+          - id: c38
+            component:
+              Card:
+                child: c39
+          - id: c39
+            component:
+              Card:
+                child: c40
+          - id: c40
+            component:
+              Text:
+                text: End
+
+- name: test_validate_recursion_limit_valid_v09
+  description: Tests that global recursion limit is valid in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface:
+        surfaceId: test-surface
+        catalogId: std
+    - version: v0.9
+      updateComponents:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component: Card
+            child: c0
+          - id: c0
+            component: Card
+            child: c1
+          - id: c1
+            component: Card
+            child: c2
+          - id: c2
+            component: Card
+            child: c3
+          - id: c3
+            component: Card
+            child: c4
+          - id: c4
+            component: Card
+            child: c5
+          - id: c5
+            component: Card
+            child: c6
+          - id: c6
+            component: Card
+            child: c7
+          - id: c7
+            component: Card
+            child: c8
+          - id: c8
+            component: Card
+            child: c9
+          - id: c9
+            component: Card
+            child: c10
+          - id: c10
+            component: Card
+            child: c11
+          - id: c11
+            component: Card
+            child: c12
+          - id: c12
+            component: Card
+            child: c13
+          - id: c13
+            component: Card
+            child: c14
+          - id: c14
+            component: Card
+            child: c15
+          - id: c15
+            component: Card
+            child: c16
+          - id: c16
+            component: Card
+            child: c17
+          - id: c17
+            component: Card
+            child: c18
+          - id: c18
+            component: Card
+            child: c19
+          - id: c19
+            component: Card
+            child: c20
+          - id: c20
+            component: Card
+            child: c21
+          - id: c21
+            component: Card
+            child: c22
+          - id: c22
+            component: Card
+            child: c23
+          - id: c23
+            component: Card
+            child: c24
+          - id: c24
+            component: Card
+            child: c25
+          - id: c25
+            component: Card
+            child: c26
+          - id: c26
+            component: Card
+            child: c27
+          - id: c27
+            component: Card
+            child: c28
+          - id: c28
+            component: Card
+            child: c29
+          - id: c29
+            component: Card
+            child: c30
+          - id: c30
+            component: Card
+            child: c31
+          - id: c31
+            component: Card
+            child: c32
+          - id: c32
+            component: Card
+            child: c33
+          - id: c33
+            component: Card
+            child: c34
+          - id: c34
+            component: Card
+            child: c35
+          - id: c35
+            component: Card
+            child: c36
+          - id: c36
+            component: Card
+            child: c37
+          - id: c37
+            component: Card
+            child: c38
+          - id: c38
+            component: Card
+            child: c39
+          - id: c39
+            component: Card
+            child: c40
+          - id: c40
+            component: Text
+            text: End
+
+- name: test_validate_global_recursion_limit_exceeded_v09
+  description: Tests that global recursion limit is exceeded for data model in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema: "test_data/simplified_catalog_v09.json"
+  action: validate
+  payload:
+    - version: v0.9
+      updateDataModel:
+        surfaceId: test-surface
+        value:
+          level: 0
+          next:
+            level: 1
+            next:
+              level: 2
+              next:
+                level: 3
+                next:
+                  level: 4
+                  next:
+                    level: 5
+                    next:
+                      level: 6
+                      next:
+                        level: 7
+                        next:
+                          level: 8
+                          next:
+                            level: 9
+                            next:
+                              level: 10
+                              next:
+                                level: 11
+                                next:
+                                  level: 12
+                                  next:
+                                    level: 13
+                                    next:
+                                      level: 14
+                                      next:
+                                        level: 15
+                                        next:
+                                          level: 16
+                                          next:
+                                            level: 17
+                                            next:
+                                              level: 18
+                                              next:
+                                                level: 19
+                                                next:
+                                                  level: 20
+                                                  next:
+                                                    level: 21
+                                                    next:
+                                                      level: 22
+                                                      next:
+                                                        level: 23
+                                                        next:
+                                                          level: 24
+                                                          next:
+                                                            level: 25
+                                                            next:
+                                                              level: 26
+                                                              next:
+                                                                level: 27
+                                                                next:
+                                                                  level: 28
+                                                                  next:
+                                                                    level: 29
+                                                                    next:
+                                                                      level: 30
+                                                                      next:
+                                                                        level: 31
+                                                                        next:
+                                                                          level: 32
+                                                                          next:
+                                                                            level: 33
+                                                                            next:
+                                                                              level: 34
+                                                                              next:
+                                                                                level: 35
+                                                                                next:
+                                                                                  level: 36
+                                                                                  next:
+                                                                                    level: 37
+                                                                                    next:
+                                                                                      level: 38
+                                                                                      next:
+                                                                                        level: 39
+                                                                                        next:
+                                                                                          level: 40
+                                                                                          next:
+                                                                                            level: 41
+                                                                                            next:
+                                                                                              level: 42
+                                                                                              next:
+                                                                                                level: 43
+                                                                                                next:
+                                                                                                  level: 44
+                                                                                                  next:
+                                                                                                    level: 45
+                                                                                                    next:
+                                                                                                      level: 46
+                                                                                                      next:
+                                                                                                        level: 47
+                                                                                                        next:
+                                                                                                          level: 48
+                                                                                                          next:
+                                                                                                            level: 49
+                                                                                                            next:
+                                                                                                              level: 50
+                                                                                                              next:
+                                                                                                                level: 51
+                                                                                                                next:
+                                                                                                                  level: 52
+                                                                                                                  next:
+                                                                                                                    level: 53
+                                                                                                                    next:
+                                                                                                                      level: 54
+                                                                                                                      next:
+                                                                                                                        level: 55
+  expect_error: Global recursion limit exceeded
+
+- name: test_validate_circular_reference_v09
+  description: Tests that circular references are detected in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "test_catalog"
+      components:
+        Card:
+          type: object
+          properties:
+            component: {const: "Card"}
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required: ["component", "child"]
+      $defs:
+        anyComponent:
+          oneOf:
+            - {$ref: "#/components/Card"}
+          discriminator: {propertyName: "component"}
+  action: validate
+  payload:
+    - version: v0.9
+      createSurface: {surfaceId: "s1", catalogId: "test_catalog"}
+    - version: v0.9
+      updateComponents:
+        surfaceId: "s1"
+        components:
+          - id: "root"
+            component: "Card"
+            child: "c1"
+          - id: "c1"
+            component: "Card"
+            child: "root"
+  expect_error: Circular reference detected
+
+- name: test_validate_multi_surface_v08
+  description: Tests that multiple surfaces with different root IDs validate correctly.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        surfaceId: surface-a
+        root: root-a
+    - beginRendering:
+        surfaceId: surface-b
+        root: root-b
+    - surfaceUpdate:
+        surfaceId: surface-a
+        components:
+          - id: root-a
+            component:
+              Card:
+                child: child-a
+          - id: child-a
+            component:
+              Text:
+                text: Hello A
+    - surfaceUpdate:
+        surfaceId: surface-b
+        components:
+          - id: root-b
+            component:
+              Card:
+                child: child-b
+          - id: child-b
+            component:
+              Text:
+                text: Hello B
+
+- name: test_validate_multi_surface_missing_root_v08
+  description: Tests that missing root in one surface still fails validation.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - beginRendering:
+        surfaceId: surface-a
+        root: root-a
+    - beginRendering:
+        surfaceId: surface-b
+        root: root-b
+    - surfaceUpdate:
+        surfaceId: surface-a
+        components:
+          - id: root-a
+            component:
+              Text:
+                text: Hello A
+    - surfaceUpdate:
+        surfaceId: surface-b
+        components:
+          - id: not-root-b
+            component:
+              Text:
+                text: Hello B
+  expect_error: Missing root component.*root-b
+
+- name: test_incremental_update_no_root_v08
+  description: Incremental update without root component should pass.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: contact-card
+        components:
+          - id: main_card
+            component:
+              Card:
+                child: col
+          - id: col
+            component:
+              Text:
+                text: Updated
+
+- name: test_incremental_update_no_root_v09
+  description: Incremental update without root component should pass (v0.9).
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: std
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: contact-card
+        components:
+          - id: card1
+            component: Card
+            child: text1
+          - id: text1
+            component: Text
+            text: Updated
+
+- name: test_incremental_update_orphans_allowed_v08
+  description: Incremental update with 'orphaned' components should pass.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: contact-card
+        components:
+          - id: text1
+            component:
+              Text:
+                text: Hello
+          - id: text2
+            component:
+              Text:
+                text: World
+
+- name: test_incremental_update_self_ref_still_fails_v08
+  description: Self-references should still be caught in incremental updates (v0.8).
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: s1
+        components:
+          - id: card1
+            component:
+              Card:
+                child: card1
+  expect_error: Self-reference detected
+
+- name: test_incremental_update_self_ref_still_fails_v09
+  description: Self-references should still be caught in incremental updates (v0.9).
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: std
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: s1
+        components:
+          - id: card1
+            component: Card
+            child: card1
+  expect_error: Self-reference detected
+
+- name: test_incremental_update_cycle_still_fails_v08
+  description: Cycles should still be caught in incremental updates (v0.8).
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Card:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: s1
+        components:
+          - id: a
+            component:
+              Card:
+                child: b
+          - id: b
+            component:
+              Card:
+                child: a
+  expect_error: Circular reference detected
+
+- name: test_incremental_update_cycle_still_fails_v09
+  description: Cycles should still be caught in incremental updates (v0.9).
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: std
+      components:
+        Card:
+          type: object
+          properties:
+            component:
+              const: Card
+            child:
+              $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
+          required:
+            - component
+            - child
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Card"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: s1
+        components:
+          - id: a
+            component: Card
+            child: b
+          - id: b
+            component: Card
+            child: a
+  expect_error: Circular reference detected
+
+- name: test_incremental_update_duplicates_still_fail_v08
+  description: Duplicate IDs should still be caught in incremental updates (v0.8).
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Text:
+          type: object
+          properties:
+            text:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: s1
+        components:
+          - id: text1
+            component:
+              Text:
+                text: A
+          - id: text1
+            component:
+              Text:
+                text: B
+  expect_error: Duplicate component ID
+
+- name: test_incremental_update_duplicates_still_fail_v09
+  description: Duplicate IDs should still be caught in incremental updates (v0.9).
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: std
+      components:
+        Text:
+          type: object
+          properties:
+            component:
+              const: Text
+            text:
+              type: string
+          required:
+            - component
+            - text
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator:
+            propertyName: component
+  action: validate
+  payload:
+    - version: v0.9
+      updateComponents:
+        surfaceId: s1
+        components:
+          - id: text1
+            component: Text
+            text: A
+          - id: text1
+            component: Text
+            text: B
+  expect_error: Duplicate component ID
+
+- name: test_validate_global_recursion_limit_exceeded_v08
+  description: Tests that global recursion limit is exceeded in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        DeepComp:
+          type: object
+          additionalProperties: true
+  action: validate
+  payload:
+    - beginRendering:
+        surfaceId: test-surface
+        root: root
+    - surfaceUpdate:
+        surfaceId: test-surface
+        components:
+          - id: root
+            component:
+              DeepComp:
+                level: 0
+                next:
+                  level: 1
+                  next:
+                    level: 2
+                    next:
+                      level: 3
+                      next:
+                        level: 4
+                        next:
+                          level: 5
+                          next:
+                            level: 6
+                            next:
+                              level: 7
+                              next:
+                                level: 8
+                                next:
+                                  level: 9
+                                  next:
+                                    level: 10
+                                    next:
+                                      level: 11
+                                      next:
+                                        level: 12
+                                        next:
+                                          level: 13
+                                          next:
+                                            level: 14
+                                            next:
+                                              level: 15
+                                              next:
+                                                level: 16
+                                                next:
+                                                  level: 17
+                                                  next:
+                                                    level: 18
+                                                    next:
+                                                      level: 19
+                                                      next:
+                                                        level: 20
+                                                        next:
+                                                          level: 21
+                                                          next:
+                                                            level: 22
+                                                            next:
+                                                              level: 23
+                                                              next:
+                                                                level: 24
+                                                                next:
+                                                                  level: 25
+                                                                  next:
+                                                                    level: 26
+                                                                    next:
+                                                                      level: 27
+                                                                      next:
+                                                                        level: 28
+                                                                        next:
+                                                                          level: 29
+                                                                          next:
+                                                                            level: 30
+                                                                            next:
+                                                                              level: 31
+                                                                              next:
+                                                                                level: 32
+                                                                                next:
+                                                                                  level: 33
+                                                                                  next:
+                                                                                    level: 34
+                                                                                    next:
+                                                                                      level: 35
+                                                                                      next:
+                                                                                        level: 36
+                                                                                        next:
+                                                                                          level: 37
+                                                                                          next:
+                                                                                            level: 38
+                                                                                            next:
+                                                                                              level: 39
+                                                                                              next:
+                                                                                                level: 40
+                                                                                                next:
+                                                                                                  level: 41
+                                                                                                  next:
+                                                                                                    level: 42
+                                                                                                    next:
+                                                                                                      level: 43
+                                                                                                      next:
+                                                                                                        level: 44
+                                                                                                        next:
+                                                                                                          level: 45
+                                                                                                          next:
+                                                                                                            level: 46
+                                                                                                            next:
+                                                                                                              level: 47
+                                                                                                              next:
+                                                                                                                level: 48
+                                                                                                                next:
+                                                                                                                  level: 49
+                                                                                                                  next:
+                                                                                                                    level: 50
+                                                                                                                    next:
+                                                                                                                      level: 51
+                                                                                                                      next:
+                                                                                                                        level: 52
+                                                                                                                        next:
+                                                                                                                          level: 53
+                                                                                                                          next:
+                                                                                                                            level: 54
+                                                                                                                            next:
+                                                                                                                              level: 55
+  expect_error: Global recursion limit exceeded
+
+- name: test_validate_invalid_child_type
+  description: Tests that invalid child type (number instead of string) throws.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: standard
+      components:
+        Container:
+          type: object
+          properties:
+            child:
+              type: string
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: s1
+        components:
+          - id: c1
+            component:
+              Container:
+                child: 123
+  expect_error: "123 is not of type 'string'"
+
+- name: test_custom_catalog_validation_success_v09
+  description: Tests validation success with a custom catalog in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "https://example.com/custom_catalog"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: [component, text]
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator: {propertyName: "component"}
+  action: validate
+  payload:
+    - version: "v0.9"
+      updateComponents:
+        surfaceId: "s1"
+        components:
+          - id: "root"
+            component: "Text"
+            text: "hello"
+
+- name: test_custom_catalog_validation_success_v08
+  description: Tests validation success with a custom catalog in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "custom"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: "s1"
+        components:
+          - id: "root"
+            component:
+              Text:
+                text: "hello"
+
+- name: test_custom_catalog_validation_failure_v08
+  description: Tests validation failure with a custom catalog in v0.8.
+  catalog:
+    version: "0.8"
+    s2c_schema: "test_data/simplified_s2c_v08.json"
+    catalog_schema:
+      catalogId: "custom"
+      components:
+        Text:
+          type: object
+          properties:
+            text: {type: string}
+  action: validate
+  payload:
+    - surfaceUpdate:
+        surfaceId: "s1"
+        components:
+          - id: "root"
+            component:
+              Text:
+                text: 123
+  expect_error: "123 is not of type 'string'"
+
+- name: test_custom_catalog_validation_failure_v09
+  description: Tests validation failure with a custom catalog in v0.9.
+  catalog:
+    version: "0.9"
+    common_types_schema: "test_data/simplified_common_types_v09.json"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema:
+      catalogId: "custom"
+      components:
+        Text:
+          type: object
+          properties:
+            component: {const: "Text"}
+            text: {type: string}
+          required: [component, text]
+      $defs:
+        anyComponent:
+          oneOf:
+            - $ref: "#/components/Text"
+          discriminator: {propertyName: "component"}
+  action: validate
+  payload:
+    - version: "v0.9"
+      updateComponents:
+        surfaceId: "s1"
+        components:
+          - id: "root"
+            component: "Text"
+            text: 123
+  expect_error: "123 is not of type 'string'"

--- a/Tests/A2UIConformanceTests/Resources/test_data/simplified_catalog_v08.json
+++ b/Tests/A2UIConformanceTests/Resources/test_data/simplified_catalog_v08.json
@@ -1,0 +1,106 @@
+{
+  "catalogId": "test_catalog",
+  "components": {
+    "Container": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "ComponentId"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "Card": {
+      "type": "object",
+      "properties": {
+        "child": {
+          "type": "string",
+          "title": "ComponentId"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "title": "ComponentId"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "Text": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Loading": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "List": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "Row": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "object",
+          "properties": {
+            "explicitList": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "componentId",
+            "dataBinding"
+          ]
+        }
+      },
+      "required": [
+        "children"
+      ]
+    },
+    "Column": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "object",
+          "properties": {
+            "explicitList": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "title": "ComponentId"
+              }
+            }
+          }
+        }
+      }
+    },
+    "AudioPlayer": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "object",
+          "properties": {
+            "literalString": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "url"
+      ]
+    }
+  }
+}

--- a/Tests/A2UIConformanceTests/Resources/test_data/simplified_catalog_v09.json
+++ b/Tests/A2UIConformanceTests/Resources/test_data/simplified_catalog_v09.json
@@ -1,0 +1,125 @@
+{
+  "$id": "https://a2ui.org/specification/v0_9/catalog.json",
+  "catalogId": "test_catalog",
+  "components": {
+    "Container": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" }
+      ],
+      "properties": {
+        "component": { "const": "Container" },
+        "children": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": [ "component", "children" ]
+    },
+    "Card": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" }
+      ],
+      "properties": {
+        "component": { "const": "Card" },
+        "child": { "$ref": "common_types.json#/$defs/ComponentId" }
+      },
+      "required": [ "component", "child" ]
+    },
+    "Text": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" }
+      ],
+      "properties": {
+        "component": { "const": "Text" },
+        "text": { "$ref": "common_types.json#/$defs/DynamicString" }
+      },
+      "required": [ "component", "text" ]
+    },
+    "Column": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" }
+      ],
+      "properties": {
+        "component": { "const": "Column" },
+        "children": { "$ref": "common_types.json#/$defs/ChildList" }
+      },
+      "required": [ "component", "children" ]
+    },
+    "AudioPlayer": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "component": { "const": "AudioPlayer" },
+            "url": { "$ref": "common_types.json#/$defs/DynamicString" },
+            "description": { "$ref": "common_types.json#/$defs/DynamicString" }
+          },
+          "required": [ "component", "url" ]
+        }
+      ]
+    },
+    "List": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "component": { "const": "List" },
+            "children": { "$ref": "common_types.json#/$defs/ChildList" },
+            "direction": {
+              "type": "string",
+              "enum": [ "vertical", "horizontal" ]
+            }
+          },
+          "required": [ "component", "children" ]
+        }
+      ]
+    },
+    "Row": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "component": { "const": "Row" },
+            "children": { "$ref": "common_types.json#/$defs/ChildList" }
+          },
+          "required": [ "component", "children" ]
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "CatalogComponentCommon": {
+      "type": "object",
+      "properties": { "weight": { "type": "number" } }
+    },
+    "anyComponent": {
+      "oneOf": [
+        { "$ref": "#/components/Container" },
+        { "$ref": "#/components/Card" },
+        { "$ref": "#/components/Text" },
+        { "$ref": "#/components/Column" },
+        { "$ref": "#/components/AudioPlayer" },
+        { "$ref": "#/components/List" },
+        { "$ref": "#/components/Row" }
+      ],
+      "discriminator": { "propertyName": "component" }
+    }
+  }
+}

--- a/Tests/A2UIConformanceTests/Resources/test_data/simplified_common_types_v09.json
+++ b/Tests/A2UIConformanceTests/Resources/test_data/simplified_common_types_v09.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/specification/v0_9/common_types.json",
+  "title": "A2UI Common Types",
+  "$defs": {
+    "ComponentId": {
+      "type": "string"
+    },
+    "AccessibilityAttributes": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/DynamicString"
+        }
+      }
+    },
+    "Action": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "ComponentCommon": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/ComponentId"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "DataBinding": {
+      "type": "object"
+    },
+    "DynamicString": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        }
+      ]
+    },
+    "DynamicValue": {
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        }
+      ]
+    },
+    "DynamicNumber": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/DataBinding"
+        }
+      ]
+    },
+    "ChildList": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ComponentId"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "componentId": {
+              "$ref": "#/$defs/ComponentId"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "componentId",
+            "path"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/Tests/A2UIConformanceTests/Resources/test_data/simplified_s2c_v08.json
+++ b/Tests/A2UIConformanceTests/Resources/test_data/simplified_s2c_v08.json
@@ -1,0 +1,75 @@
+{
+  "title": "A2UI Message Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "beginRendering": {
+      "type": "object",
+      "properties": {
+        "surfaceId": { "type": "string" },
+        "root": { "type": "string" },
+        "styles": { "type": "object", "additionalProperties": true }
+      },
+      "required": ["surfaceId", "root"]
+    },
+    "surfaceUpdate": {
+      "type": "object",
+      "properties": {
+        "surfaceId": { "type": "string" },
+        "components": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "component": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": ["id", "component"]
+          }
+        }
+      },
+      "required": ["surfaceId", "components"]
+    },
+    "dataModelUpdate": {
+      "type": "object",
+      "properties": {
+        "surfaceId": { "type": "string" },
+        "contents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "valueString": { "type": "string" },
+              "valueNumber": { "type": "number" },
+              "valueBoolean": { "type": "boolean" },
+              "valueMap": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": { "type": "string" },
+                    "valueString": { "type": "string" },
+                    "valueNumber": { "type": "number" },
+                    "valueBoolean": { "type": "boolean" }
+                  },
+                  "required": ["key"]
+                }
+              }
+            },
+            "required": ["key"]
+          }
+        }
+      },
+      "required": ["surfaceId", "contents"]
+    },
+    "deleteSurface": {
+      "type": "object",
+      "properties": { "surfaceId": { "type": "string" } },
+      "required": ["surfaceId"]
+    }
+  }
+}

--- a/Tests/A2UIConformanceTests/Resources/test_data/simplified_s2c_v09.json
+++ b/Tests/A2UIConformanceTests/Resources/test_data/simplified_s2c_v09.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/specification/v0_9/server_to_client.json",
+  "title": "A2UI Message Schema",
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/CreateSurfaceMessage"
+    },
+    {
+      "$ref": "#/$defs/UpdateComponentsMessage"
+    },
+    {
+      "$ref": "#/$defs/UpdateDataModelMessage"
+    },
+    {
+      "$ref": "#/$defs/DeleteSurfaceMessage"
+    }
+  ],
+  "$defs": {
+    "CreateSurfaceMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "createSurface": {
+          "type": "object",
+          "properties": {
+            "surfaceId": {
+              "type": "string"
+            },
+            "catalogId": {
+              "type": "string"
+            },
+            "theme": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "surfaceId",
+            "catalogId"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "version",
+        "createSurface"
+      ],
+      "additionalProperties": false
+    },
+    "UpdateComponentsMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "updateComponents": {
+          "type": "object",
+          "properties": {
+            "surfaceId": {
+              "type": "string"
+            },
+            "root": {
+              "type": "string"
+            },
+            "components": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "catalog.json#/$defs/anyComponent"
+              }
+            }
+          },
+          "required": [
+            "surfaceId",
+            "components"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "version",
+        "updateComponents"
+      ],
+      "additionalProperties": false
+    },
+    "UpdateDataModelMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "updateDataModel": {
+          "type": "object",
+          "properties": {
+            "surfaceId": {
+              "type": "string"
+            },
+            "value": {
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "surfaceId"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "version",
+        "updateDataModel"
+      ],
+      "additionalProperties": false
+    },
+    "DeleteSurfaceMessage": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "const": "v0.9"
+        },
+        "deleteSurface": {
+          "type": "object",
+          "properties": {
+            "surfaceId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "surfaceId"
+          ]
+        }
+      },
+      "required": [
+        "version",
+        "deleteSurface"
+      ]
+    }
+  }
+}

--- a/Tests/A2UIConformanceTests/SchemaManagerConformanceTests.swift
+++ b/Tests/A2UIConformanceTests/SchemaManagerConformanceTests.swift
@@ -1,0 +1,18 @@
+// Tests/A2UIConformanceTests/SchemaManagerConformanceTests.swift
+import XCTest
+@testable import A2UISwiftCore
+
+final class SchemaManagerConformanceTests: XCTestCase {
+
+    private static var cases: [ConformanceCase] = {
+        (try? loadConformanceCases(suite: "schema_manager")) ?? []
+    }()
+
+    func test_schema_manager_conformance() throws {
+        let cases = SchemaManagerConformanceTests.cases
+        guard !cases.isEmpty else {
+            throw XCTSkip("Could not load conformance cases for 'schema_manager' — check Bundle.module resources")
+        }
+        throw XCTSkip("N/A for renderer: all schema_manager suite actions are agent-side")
+    }
+}

--- a/Tests/A2UIConformanceTests/StreamingParserConformanceTests.swift
+++ b/Tests/A2UIConformanceTests/StreamingParserConformanceTests.swift
@@ -1,0 +1,22 @@
+// Tests/A2UIConformanceTests/StreamingParserConformanceTests.swift
+import XCTest
+@testable import A2UISwiftCore
+
+final class StreamingParserConformanceTests: XCTestCase {
+
+    private static var cases: [ConformanceCase] = {
+        (try? loadConformanceCases(suite: "streaming_parser")) ?? []
+    }()
+
+    func test_streaming_parser_conformance() async throws {
+        let cases = StreamingParserConformanceTests.cases
+        guard !cases.isEmpty else {
+            throw XCTSkip("Could not load conformance cases for 'streaming_parser' — check Bundle.module resources")
+        }
+
+        for testCase in cases {
+            try skipAgentOnlyAction(testCase.action, testName: testCase.name)
+            try await runProcessChunk(testCase: testCase)
+        }
+    }
+}

--- a/Tests/A2UIConformanceTests/ValidatorConformanceTests.swift
+++ b/Tests/A2UIConformanceTests/ValidatorConformanceTests.swift
@@ -1,0 +1,27 @@
+// Tests/A2UIConformanceTests/ValidatorConformanceTests.swift
+import XCTest
+@testable import A2UISwiftCore
+
+final class ValidatorConformanceTests: XCTestCase {
+
+    private static var cases: [ConformanceCase] = {
+        (try? loadConformanceCases(suite: "validator")) ?? []
+    }()
+
+    func test_validator_conformance() throws {
+        let cases = ValidatorConformanceTests.cases
+        guard !cases.isEmpty else {
+            throw XCTSkip("Could not load conformance cases for 'validator' — check Bundle.module resources")
+        }
+
+        for testCase in cases {
+            try skipAgentOnlyAction(testCase.action, testName: testCase.name)
+            switch testCase.action {
+            case "validate":
+                try runValidate(testCase: testCase)
+            default:
+                throw XCTSkip("N/A for renderer: action '\(testCase.action)' (test: \(testCase.name))")
+            }
+        }
+    }
+}

--- a/Tests/A2UIConformanceTests/YAMLDecoder.swift
+++ b/Tests/A2UIConformanceTests/YAMLDecoder.swift
@@ -1,0 +1,612 @@
+// Tests/A2UIConformanceTests/YAMLDecoder.swift
+// Minimal YAML parser sufficient for the A2UI conformance suite files.
+// Handles: top-level sequences of mappings, nested block mappings/sequences,
+// block scalars (| and >), flow sequences/mappings (possibly spanning multiple
+// lines), single- and double-quoted strings, and string/int/bool/null scalars.
+// Does NOT handle anchors, aliases, explicit tags, or directives.
+
+import Foundation
+
+enum YAMLError: Error {
+    case parse(String)
+}
+
+/// Parse a YAML document. Returns the top-level value, typically `[Any]` for
+/// conformance suite files (a top-level sequence of test-case mappings).
+func parseYAML(_ text: String) throws -> Any {
+    var scanner = YAMLScanner(text)
+    return try scanner.parseTopLevel()
+}
+
+// MARK: - Scanner
+
+private struct YAMLScanner {
+    let source: [Character]
+    var pos: Int = 0
+
+    init(_ text: String) {
+        source = Array(text)
+    }
+
+    // MARK: Helpers
+
+    mutating func parseTopLevel() throws -> Any {
+        skipBlankLines()
+        guard pos < source.count else { return NSNull() }
+        let lineIndent = peekLineIndent()
+        let firstChar = charAtLineStart()
+        if firstChar == "-" {
+            return try parseBlockSequence(atIndent: lineIndent)
+        }
+        if firstChar == "[" {
+            advancePastIndent()
+            return try parseFlowSequence()
+        }
+        if firstChar == "{" {
+            advancePastIndent()
+            return try parseFlowMapping()
+        }
+        if lineHasMappingKey() {
+            return try parseBlockMapping(atIndent: lineIndent)
+        }
+        advancePastIndent()
+        let raw = collectScalar()
+        return parseScalar(raw)
+    }
+
+    /// Indent of the next line without moving pos.
+    func peekLineIndent() -> Int {
+        var i = pos
+        var col = 0
+        while i < source.count && source[i] == " " { col += 1; i += 1 }
+        return col
+    }
+
+    /// First non-space char on the current line.
+    func charAtLineStart() -> Character? {
+        var i = pos
+        while i < source.count && source[i] == " " { i += 1 }
+        guard i < source.count else { return nil }
+        return source[i]
+    }
+
+    /// Move pos past leading spaces.
+    mutating func advancePastIndent() {
+        while pos < source.count && source[pos] == " " { pos += 1 }
+    }
+
+    /// Does the current line look like a mapping key (key: value)?
+    func lineHasMappingKey() -> Bool {
+        var i = pos
+        while i < source.count && source[i] == " " { i += 1 }
+        return lookaheadIsMappingKey(from: i)
+    }
+
+    func lookaheadIsMappingKey(from start: Int) -> Bool {
+        var i = start
+        if i < source.count && (source[i] == "\"" || source[i] == "'") {
+            let q = source[i]; i += 1
+            while i < source.count && source[i] != q { i += 1 }
+            i += 1
+            while i < source.count && source[i] == " " { i += 1 }
+            return i < source.count && source[i] == ":"
+        }
+        while i < source.count && source[i] != "\n" {
+            let ch = source[i]
+            if ch == ":" {
+                let next = (i + 1 < source.count) ? source[i + 1] : "\0"
+                if next == " " || next == "\n" || next == "\t" { return true }
+            }
+            i += 1
+        }
+        return false
+    }
+
+    /// Skip blank lines and comment-only lines, leaving pos at next content.
+    mutating func skipBlankLines() {
+        while pos < source.count {
+            let start = pos
+            while pos < source.count && (source[pos] == " " || source[pos] == "\t") { pos += 1 }
+            if pos < source.count {
+                if source[pos] == "\n" { pos += 1; continue }
+                if source[pos] == "\r" { pos += 1; continue }
+                if source[pos] == "#" {
+                    while pos < source.count && source[pos] != "\n" { pos += 1 }
+                    if pos < source.count { pos += 1 }
+                    continue
+                }
+            }
+            pos = start; break
+        }
+    }
+
+    mutating func skipLineWhitespace() {
+        while pos < source.count && (source[pos] == " " || source[pos] == "\t") { pos += 1 }
+        if pos < source.count && source[pos] == "#" {
+            while pos < source.count && source[pos] != "\n" { pos += 1 }
+        }
+    }
+
+    mutating func consumeNewline() {
+        if pos < source.count && source[pos] == "\n" { pos += 1 }
+        else if pos < source.count && source[pos] == "\r" {
+            pos += 1
+            if pos < source.count && source[pos] == "\n" { pos += 1 }
+        }
+    }
+
+    mutating func consumeRestOfLine() {
+        while pos < source.count && source[pos] != "\n" { pos += 1 }
+        consumeNewline()
+    }
+
+    // MARK: Block sequence
+
+    mutating func parseBlockSequence(atIndent seqIndent: Int) throws -> [Any] {
+        var result: [Any] = []
+        while pos < source.count {
+            skipBlankLines()
+            guard pos < source.count else { break }
+            let lineIndent = peekLineIndent()
+            if lineIndent < seqIndent { break }
+            if lineIndent > seqIndent { break }
+
+            // Must be a "- " or "-\n" entry.
+            var look = pos
+            while look < source.count && source[look] == " " { look += 1 }
+            guard look < source.count && source[look] == "-" else { break }
+            let next = (look + 1 < source.count) ? source[look + 1] : "\0"
+            guard next == " " || next == "\n" || next == "\t" else { break }
+
+            pos = look + 1  // past "-"
+            if pos < source.count && (source[pos] == " " || source[pos] == "\t") { pos += 1 }
+
+            skipLineWhitespace()
+
+            if pos >= source.count || source[pos] == "\n" {
+                consumeNewline()
+                skipBlankLines()
+                if pos < source.count {
+                    let childIndent = peekLineIndent()
+                    if childIndent > seqIndent {
+                        result.append(try parseValue(atIndent: childIndent))
+                    } else {
+                        result.append(NSNull())
+                    }
+                } else {
+                    result.append(NSNull())
+                }
+            } else {
+                // Inline content.
+                let ch = source[pos]
+                if ch == "[" {
+                    result.append(try parseFlowSequence())
+                    consumeRestOfLine()
+                } else if ch == "{" {
+                    result.append(try parseFlowMapping())
+                    consumeRestOfLine()
+                } else if ch == "|" || ch == ">" {
+                    result.append(try parseBlockScalar(keyIndent: seqIndent + 2))
+                } else if lookaheadIsMappingKey(from: pos) {
+                    // Inline mapping: first key starts here, continuation lines
+                    // are at seqIndent + 2.
+                    result.append(try parseInlineBlockMapping(keyIndent: seqIndent + 2))
+                } else {
+                    let raw = collectScalar()
+                    result.append(parseScalar(raw))
+                    consumeRestOfLine()
+                }
+            }
+        }
+        return result
+    }
+
+    // MARK: Block mapping
+
+    mutating func parseBlockMapping(atIndent mapIndent: Int) throws -> [String: Any] {
+        var result: [String: Any] = [:]
+        while pos < source.count {
+            skipBlankLines()
+            guard pos < source.count else { break }
+            let lineIndent = peekLineIndent()
+            if lineIndent < mapIndent { break }
+            if lineIndent > mapIndent { break }  // unexpected deeper indent
+
+            var look = pos
+            while look < source.count && source[look] == " " { look += 1 }
+            guard look < source.count else { break }
+
+            // Sequence item in this context? Stop.
+            if source[look] == "-" {
+                let nx = (look + 1 < source.count) ? source[look + 1] : "\0"
+                if nx == " " || nx == "\n" { break }
+            }
+
+            pos = look
+            let (key, value) = try parseKeyValuePair(mapIndent: mapIndent)
+            result[key] = value
+        }
+        return result
+    }
+
+    /// Parse a single key: value pair starting at current pos (already
+    /// positioned at the key character, no leading spaces).
+    /// `mapIndent` is used to determine when nested block values end.
+    mutating func parseKeyValuePair(mapIndent: Int) throws -> (String, Any) {
+        let key = try parseKey()
+        skipLineWhitespace()
+        guard pos < source.count && source[pos] == ":" else {
+            return (key, NSNull())
+        }
+        pos += 1  // consume ":"
+
+        if pos < source.count && (source[pos] == " " || source[pos] == "\t") { pos += 1 }
+        skipLineWhitespace()
+
+        let value: Any
+        if pos >= source.count || source[pos] == "\n" {
+            consumeNewline()
+            skipBlankLines()
+            if pos < source.count {
+                let childIndent = peekLineIndent()
+                if childIndent > mapIndent {
+                    value = try parseValue(atIndent: childIndent)
+                } else {
+                    value = NSNull()
+                }
+            } else {
+                value = NSNull()
+            }
+        } else {
+            let ch = source[pos]
+            if ch == "[" {
+                value = try parseFlowSequence()
+                consumeRestOfLine()
+            } else if ch == "{" {
+                value = try parseFlowMapping()
+                consumeRestOfLine()
+            } else if ch == "|" || ch == ">" {
+                value = try parseBlockScalar(keyIndent: mapIndent + 2)
+            } else {
+                let raw = collectScalar()
+                value = parseScalar(raw)
+                consumeRestOfLine()
+            }
+        }
+        return (key, value)
+    }
+
+    /// Parse a block mapping where the first key starts inline (e.g. after "- ").
+    /// Continuation keys must be at `keyIndent`.
+    mutating func parseInlineBlockMapping(keyIndent: Int) throws -> [String: Any] {
+        var result: [String: Any] = [:]
+        // First key-value is on the current line (pos already at first char).
+        let (k0, v0) = try parseKeyValuePair(mapIndent: keyIndent)
+        result[k0] = v0
+        // Collect additional keys at keyIndent.
+        while pos < source.count {
+            skipBlankLines()
+            guard pos < source.count else { break }
+            let lineIndent = peekLineIndent()
+            if lineIndent < keyIndent { break }
+            if lineIndent > keyIndent { break }
+
+            var look = pos
+            while look < source.count && source[look] == " " { look += 1 }
+            guard look < source.count else { break }
+            if source[look] == "-" { break }
+
+            pos = look
+            let (key, value) = try parseKeyValuePair(mapIndent: keyIndent)
+            result[key] = value
+        }
+        return result
+    }
+
+    // MARK: Dispatch
+
+    mutating func parseValue(atIndent indent: Int) throws -> Any {
+        skipBlankLines()
+        guard pos < source.count else { return NSNull() }
+
+        let lineIndent = peekLineIndent()
+        var look = pos
+        while look < source.count && source[look] == " " { look += 1 }
+        guard look < source.count else { return NSNull() }
+        let ch = source[look]
+
+        if ch == "-" {
+            let nx = (look + 1 < source.count) ? source[look + 1] : "\0"
+            if nx == " " || nx == "\n" {
+                return try parseBlockSequence(atIndent: lineIndent)
+            }
+        }
+        if ch == "[" {
+            pos = look
+            return try parseFlowSequence()
+        }
+        if ch == "{" {
+            pos = look
+            return try parseFlowMapping()
+        }
+        if lookaheadIsMappingKey(from: look) {
+            return try parseBlockMapping(atIndent: lineIndent)
+        }
+        pos = look
+        let raw = collectScalar()
+        return parseScalar(raw)
+    }
+
+    // MARK: Block scalar
+
+    mutating func parseBlockScalar(keyIndent: Int) throws -> String {
+        let indicator = source[pos]; pos += 1
+
+        var chompStrip = false
+        while pos < source.count && source[pos] != "\n" {
+            if source[pos] == "-" { chompStrip = true }
+            pos += 1
+        }
+        consumeNewline()
+
+        var blockIndent = -1
+        var lines: [String] = []
+        while pos < source.count {
+            var i = pos
+            var lineCol = 0
+            while i < source.count && source[i] == " " { lineCol += 1; i += 1 }
+            let lineIsBlank = (i >= source.count || source[i] == "\n" || source[i] == "\r")
+            if lineIsBlank {
+                lines.append("")
+                while pos < source.count && source[pos] != "\n" { pos += 1 }
+                consumeNewline()
+                continue
+            }
+            if blockIndent == -1 { blockIndent = lineCol }
+            if lineCol < blockIndent { break }
+            pos += blockIndent
+            var chars: [Character] = []
+            while pos < source.count && source[pos] != "\n" {
+                chars.append(source[pos]); pos += 1
+            }
+            consumeNewline()
+            lines.append(String(chars))
+        }
+
+        // Remove trailing blank lines for clip (default) or strip.
+        if chompStrip {
+            while lines.last == "" { lines.removeLast() }
+        }
+
+        if indicator == "|" {
+            var result = lines.joined(separator: "\n")
+            if !chompStrip { result += "\n" }
+            return result
+        } else {
+            var parts: [String] = []
+            for line in lines {
+                if line.isEmpty {
+                    parts.append("\n")
+                } else if let last = parts.last, !last.hasSuffix("\n") {
+                    parts[parts.count - 1] = last + " " + line
+                } else {
+                    parts.append(line)
+                }
+            }
+            var result = parts.joined()
+            if !chompStrip { result += "\n" }
+            return result
+        }
+    }
+
+    // MARK: Flow sequence
+
+    mutating func parseFlowSequence() throws -> [Any] {
+        guard pos < source.count && source[pos] == "[" else {
+            throw YAMLError.parse("Expected '['")
+        }
+        pos += 1
+        var result: [Any] = []
+        skipFlowWhitespace()
+        if pos < source.count && source[pos] == "]" { pos += 1; return result }
+        while pos < source.count {
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "]" { pos += 1; break }
+            result.append(try parseFlowValue())
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "," { pos += 1 }
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "]" { pos += 1; break }
+        }
+        return result
+    }
+
+    // MARK: Flow mapping
+
+    mutating func parseFlowMapping() throws -> [String: Any] {
+        guard pos < source.count && source[pos] == "{" else {
+            throw YAMLError.parse("Expected '{'")
+        }
+        pos += 1
+        var result: [String: Any] = [:]
+        skipFlowWhitespace()
+        if pos < source.count && source[pos] == "}" { pos += 1; return result }
+        while pos < source.count {
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "}" { pos += 1; break }
+            let key: String
+            if pos < source.count && source[pos] == "\"" {
+                key = try parseDoubleQuotedString()
+            } else if pos < source.count && source[pos] == "'" {
+                key = parseSingleQuotedString()
+            } else {
+                var chars: [Character] = []
+                while pos < source.count {
+                    let c = source[pos]
+                    if c == ":" || c == "," || c == "}" || c == "\n" { break }
+                    chars.append(c); pos += 1
+                }
+                key = String(chars).trimmingCharacters(in: .whitespaces)
+            }
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == ":" { pos += 1 }
+            skipFlowWhitespace()
+            result[key] = try parseFlowValue()
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "," { pos += 1 }
+            skipFlowWhitespace()
+            if pos < source.count && source[pos] == "}" { pos += 1; break }
+        }
+        return result
+    }
+
+    mutating func skipFlowWhitespace() {
+        while pos < source.count {
+            let ch = source[pos]
+            if ch == " " || ch == "\t" || ch == "\n" || ch == "\r" {
+                pos += 1
+            } else if ch == "#" {
+                while pos < source.count && source[pos] != "\n" { pos += 1 }
+            } else {
+                break
+            }
+        }
+    }
+
+    mutating func parseFlowValue() throws -> Any {
+        skipFlowWhitespace()
+        guard pos < source.count else { return NSNull() }
+        let ch = source[pos]
+        if ch == "[" { return try parseFlowSequence() }
+        if ch == "{" { return try parseFlowMapping() }
+        if ch == "\"" { return try parseDoubleQuotedString() }
+        if ch == "'" { return parseSingleQuotedString() }
+        var chars: [Character] = []
+        while pos < source.count {
+            let c = source[pos]
+            if c == "," || c == "]" || c == "}" { break }
+            if c == "\n" || c == "\r" {
+                pos += 1
+                skipFlowWhitespace()
+                if !chars.isEmpty { chars.append(" ") }
+                continue
+            }
+            if c == "#" {
+                while pos < source.count && source[pos] != "\n" { pos += 1 }
+                continue
+            }
+            chars.append(c); pos += 1
+        }
+        let raw = String(chars).trimmingCharacters(in: .whitespaces)
+        return parseScalar(raw)
+    }
+
+    // MARK: Quoted strings
+
+    mutating func parseDoubleQuotedString() throws -> String {
+        guard pos < source.count && source[pos] == "\"" else {
+            throw YAMLError.parse("Expected '\"'")
+        }
+        pos += 1
+        var chars: [Character] = []
+        while pos < source.count {
+            let c = source[pos]; pos += 1
+            if c == "\"" { break }
+            if c == "\\" && pos < source.count {
+                let esc = source[pos]; pos += 1
+                switch esc {
+                case "n": chars.append("\n")
+                case "t": chars.append("\t")
+                case "r": chars.append("\r")
+                case "\"": chars.append("\"")
+                case "\\": chars.append("\\")
+                case "/": chars.append("/")
+                case "b": chars.append("\u{08}")
+                case "f": chars.append("\u{0C}")
+                case "u":
+                    var hex = ""
+                    for _ in 0..<4 {
+                        if pos < source.count { hex.append(source[pos]); pos += 1 }
+                    }
+                    if let code = UInt32(hex, radix: 16), let scalar = Unicode.Scalar(code) {
+                        chars.append(Character(scalar))
+                    }
+                default: chars.append(esc)
+                }
+            } else {
+                chars.append(c)
+            }
+        }
+        return String(chars)
+    }
+
+    mutating func parseSingleQuotedString() -> String {
+        guard pos < source.count && source[pos] == "'" else { return "" }
+        pos += 1
+        var chars: [Character] = []
+        while pos < source.count {
+            let c = source[pos]; pos += 1
+            if c == "'" {
+                if pos < source.count && source[pos] == "'" {
+                    chars.append("'"); pos += 1
+                } else {
+                    break
+                }
+            } else {
+                chars.append(c)
+            }
+        }
+        return String(chars)
+    }
+
+    // MARK: Key parsing
+
+    mutating func parseKey() throws -> String {
+        guard pos < source.count else { throw YAMLError.parse("Expected key") }
+        let ch = source[pos]
+        if ch == "\"" { return try parseDoubleQuotedString() }
+        if ch == "'" { return parseSingleQuotedString() }
+        var chars: [Character] = []
+        while pos < source.count {
+            let c = source[pos]
+            if c == ":" {
+                let nx = (pos + 1 < source.count) ? source[pos + 1] : "\0"
+                if nx == " " || nx == "\n" || nx == "\t" { break }
+            }
+            if c == "\n" { break }
+            chars.append(c); pos += 1
+        }
+        return String(chars).trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: Scalar
+
+    mutating func collectScalar() -> String {
+        var chars: [Character] = []
+        while pos < source.count {
+            let c = source[pos]
+            if c == "\n" { break }
+            if c == "#" {
+                if let last = chars.last, last == " " || last == "\t" { break }
+                if chars.isEmpty { break }
+            }
+            chars.append(c); pos += 1
+        }
+        return String(chars).trimmingCharacters(in: .whitespaces)
+    }
+
+    func parseScalar(_ s: String) -> Any {
+        if s == "null" || s == "~" || s.isEmpty { return NSNull() }
+        if s == "true" || s == "True" || s == "TRUE" { return true }
+        if s == "false" || s == "False" || s == "FALSE" { return false }
+        if let i = Int(s) { return i }
+        if let d = Double(s) { return d }
+        if s.count >= 2 {
+            let first = s.first!, last = s.last!
+            if (first == "\"" && last == "\"") || (first == "'" && last == "'") {
+                return String(s.dropFirst().dropLast())
+            }
+        }
+        return s
+    }
+}

--- a/Tests/A2UIConformanceTests/YAMLDecoderTests.swift
+++ b/Tests/A2UIConformanceTests/YAMLDecoderTests.swift
@@ -1,0 +1,109 @@
+// Tests/A2UIConformanceTests/YAMLDecoderTests.swift
+import XCTest
+import Foundation
+
+final class YAMLDecoderTests: XCTestCase {
+
+    /// Helper: locate the Resources bundle for this test target.
+    private func suitesURL() throws -> URL {
+        let bundle = Bundle.module
+        let url = try XCTUnwrap(
+            bundle.url(forResource: "suites", withExtension: nil),
+            "Cannot find Resources/suites in test bundle"
+        )
+        return url
+    }
+
+    func test_parsesValidatorSuite() throws {
+        let url = try suitesURL().appendingPathComponent("validator.yaml")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let result = try parseYAML(text)
+        let cases = try XCTUnwrap(result as? [Any])
+        XCTAssertGreaterThan(cases.count, 0, "validator.yaml should have at least one test case")
+    }
+
+    func test_parsesStreamingParserSuite() throws {
+        let url = try suitesURL().appendingPathComponent("streaming_parser.yaml")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let result = try parseYAML(text)
+        let cases = try XCTUnwrap(result as? [Any])
+        XCTAssertGreaterThan(cases.count, 0, "streaming_parser.yaml should have at least one test case")
+    }
+
+    func test_parsesCatalogSuite() throws {
+        let url = try suitesURL().appendingPathComponent("catalog.yaml")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let result = try parseYAML(text)
+        let cases = try XCTUnwrap(result as? [Any])
+        XCTAssertGreaterThan(cases.count, 0, "catalog.yaml should have at least one test case")
+    }
+
+    func test_parsesParserSuite() throws {
+        let url = try suitesURL().appendingPathComponent("parser.yaml")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let result = try parseYAML(text)
+        let cases = try XCTUnwrap(result as? [Any])
+        XCTAssertGreaterThan(cases.count, 0, "parser.yaml should have at least one test case")
+    }
+
+    func test_parsesSchemaManagerSuite() throws {
+        let url = try suitesURL().appendingPathComponent("schema_manager.yaml")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        let result = try parseYAML(text)
+        let cases = try XCTUnwrap(result as? [Any])
+        XCTAssertGreaterThan(cases.count, 0, "schema_manager.yaml should have at least one test case")
+    }
+
+    func test_caseCountsMatchExpected() throws {
+        let expectations: [(String, Int)] = [
+            ("validator.yaml", 45),
+            ("streaming_parser.yaml", 76),
+            ("catalog.yaml", 24),
+        ]
+        let suitesDir = try suitesURL()
+        for (file, expected) in expectations {
+            let url = suitesDir.appendingPathComponent(file)
+            let text = try String(contentsOf: url, encoding: .utf8)
+            let result = try parseYAML(text)
+            let cases = try XCTUnwrap(result as? [Any])
+            XCTAssertEqual(cases.count, expected,
+                "\(file): expected \(expected) cases, got \(cases.count)")
+        }
+    }
+
+    func test_simpleScalarsAndTypes() throws {
+        let yaml = """
+        - name: foo
+          count: 42
+          flag: true
+          nothing: null
+          ratio: 3.14
+        """
+        let result = try parseYAML(yaml)
+        let arr = try XCTUnwrap(result as? [[String: Any]])
+        XCTAssertEqual(arr.count, 1)
+        let first = arr[0]
+        XCTAssertEqual(first["name"] as? String, "foo")
+        XCTAssertEqual(first["count"] as? Int, 42)
+        XCTAssertEqual(first["flag"] as? Bool, true)
+        XCTAssertTrue(first["nothing"] is NSNull)
+        XCTAssertEqual(first["ratio"] as? Double, 3.14)
+    }
+
+    func test_flowSequence() throws {
+        let yaml = "items: [Text, Button, Image]\n"
+        let result = try parseYAML(yaml)
+        let dict = try XCTUnwrap(result as? [String: Any])
+        let items = try XCTUnwrap(dict["items"] as? [Any])
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items[0] as? String, "Text")
+    }
+
+    func test_flowMapping() throws {
+        let yaml = "obj: {type: object, title: foo}\n"
+        let result = try parseYAML(yaml)
+        let dict = try XCTUnwrap(result as? [String: Any])
+        let obj = try XCTUnwrap(dict["obj"] as? [String: Any])
+        XCTAssertEqual(obj["type"] as? String, "object")
+    }
+}


### PR DESCRIPTION
## Summary

Ports the A2UI conformance test harness onto the v1.0 spec branch (copilot/port-to-a2ui-v1-0). This branch vendors the upstream A2UI conformance suite (~140 cases across 5 YAML suites) and runs it under XCTest via a new A2UIConformanceTests SPM target.

The work was originally built against the v0.9 main branch; this branch rebases it onto the in-progress v1.0 port to validate the renderer against the latest spec.

What's included

- A2UIConformanceTests SPM target with vendored suites/ + test_data/ resources (parser, validator, catalog, schema_manager, streaming_parser)
- Lightweight pure-Swift YAML decoder for the suite files (no new third-party dependency)
- ConformanceCase model + Bundle.module resource loaders
- ConformanceHarness — dispatch by action, Python-aligned fuzzy error matching, XCTSkip for agent-only actions ("N/A for renderer")
- Per-suite XCTestCase classes covering the renderer-applicable actions (process_chunk, parse_full, fix_payload, validate)

Conformance results against v1.0 core

Suites were run in isolation (core + conformance target only — see "Known limitations").
| Suite | Result | Notes |
| --- | --- | --- |
| Validator | pass | |
| Catalog | pass | skips - agent-only, as designed |
| SchemaManager | pass | skips - agent-only, as designed |
| Parser | 22 failures | possible incomplete v1.0 wire format?  |
| StreamingParser | 266 failures | possible incomplete v1.0 wire format  |


Creating draft for now and will update v1.0 branch to see whether everything pass. 