### PR TITLE
fix: use upToNextMajor version rule for swift-foundation-icu

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         // Exported library product is `_FoundationICU` only.
         .package(
             url: "https://github.com/swiftlang/swift-foundation-icu.git",
-            revision: "swift-6.3.1-RELEASE"
+            .upToNextMajor(from: "0.0.10")
         ),
         .package(
             url: "https://github.com/ajevans99/swift-json-schema.git",


### PR DESCRIPTION
## Summary
- Change swift-foundation-icu dependency from a pinned `revision: "swift-6.3.1-RELEASE"` to `.upToNextMajor(from: "0.0.10")` so a2ui-swift no longer depends on an unstable-version package, allowing downstream consumers to depend on a2ui-swift via a stable version range.

Closes #73

## Test plan
- [x] `Package.swift` parses (dependency requirement is valid SwiftPM syntax)
- [ ] Verify `swift package resolve` succeeds and sample apps build against a tagged version of a2ui-swift